### PR TITLE
Remove Find Doctors link and point logo to home

### DIFF
--- a/brokers.html
+++ b/brokers.html
@@ -12,7 +12,7 @@
 <body class="font-sans text-slate-800">
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="/" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
       <nav class="hidden md:flex items-center gap-6 text-[15px]">
         <a class="hover:text-saveWine" href="providers.html">For Providers</a>
         <a class="hover:text-saveWine" href="payers.html">For Payers</a>

--- a/index.html
+++ b/index.html
@@ -40,14 +40,13 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="/" class="flex items-center gap-3">
+      <a href="index.html" class="flex items-center gap-3">
         <img src="assets/savewell-logo.png" alt="SaveWell" class="h-8 w-auto" />
       </a>
       <nav class="hidden md:flex items-center gap-6 text-[15px]">
         <a class="hover:text-saveWine" href="providers.html">For Providers</a>
         <a class="hover:text-saveWine" href="payers.html">For Payers</a>
         <a class="hover:text-saveWine" href="brokers.html">For Brokers</a>
-        <a href="results.html" class="hover:text-saveWine" title="See example results">Find Doctors</a>
       </nav>
       <div class="flex items-center gap-2">
         <a href="#" class="inline-flex items-center rounded-xl bg-saveWine px-4 py-2 text-white text-sm font-semibold hover:bg-saveWineDark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-saveWine">Login</a>
@@ -62,7 +61,6 @@
         <a class="block py-2" href="providers.html">For Providers</a>
         <a class="block py-2" href="payers.html">For Payers</a>
         <a class="block py-2" href="brokers.html">For Brokers</a>
-        <a class="block py-2" href="results.html">Find Doctors</a>
       </div>
     </div>
   </header>

--- a/payers.html
+++ b/payers.html
@@ -12,7 +12,7 @@
 <body class="font-sans text-slate-800">
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="/" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
       <nav class="hidden md:flex items-center gap-6 text-[15px]">
         <a class="hover:text-saveWine" href="providers.html">For Providers</a>
         <a class="text-saveWine font-semibold" href="payers.html">For Payers</a>

--- a/providers.html
+++ b/providers.html
@@ -13,7 +13,7 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="/" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
       <nav class="hidden md:flex items-center gap-6 text-[15px]">
         <a class="text-saveWine font-semibold" href="providers.html">For Providers</a>
         <a class="hover:text-saveWine" href="payers.html">For Payers</a>

--- a/results.html
+++ b/results.html
@@ -15,7 +15,7 @@
   <!-- Navbar (same as index) -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="/" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
       <nav class="hidden md:flex items-center gap-6 text-[15px]">
         <a class="hover:text-saveWine" href="providers.html">For Providers</a>
         <a class="hover:text-saveWine" href="payers.html">For Payers</a>


### PR DESCRIPTION
## Summary
- Remove "Find Doctors" link from navigation and mobile menu
- Make the site logo on all pages link back to `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b77924788326a5bf2aa24c7c1f69