### PR TITLE
Add mobile menu to all site pages

### DIFF
--- a/brokers.html
+++ b/brokers.html
@@ -18,7 +18,20 @@
         <a class="hover:text-saveWine" href="payers.html">For Payers</a>
         <a class="text-saveWine font-semibold" href="brokers.html">For Brokers</a>
       </nav>
-      <a href="#" class="inline-flex items-center rounded-xl bg-saveWine px-4 py-2 text-white text-sm font-semibold hover:bg-saveTealDark">Login</a>
+      <div class="flex items-center gap-2">
+        <a href="#" class="inline-flex items-center rounded-xl bg-saveWine px-4 py-2 text-white text-sm font-semibold hover:bg-saveWineDark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-saveWine">Login</a>
+        <button class="md:hidden inline-flex items-center p-2" id="menuBtn" aria-label="Open Menu">
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
+      </div>
+    </div>
+    <!-- Mobile menu -->
+    <div id="mobileMenu" class="md:hidden hidden border-t border-slate-200">
+      <div class="px-4 py-3 space-y-2">
+        <a class="block py-2" href="providers.html">For Providers</a>
+        <a class="block py-2" href="payers.html">For Payers</a>
+        <a class="block py-2 text-saveWine font-semibold" href="brokers.html">For Brokers</a>
+      </div>
     </div>
   </header>
 
@@ -40,6 +53,11 @@
   <footer class="bg-white border-t border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 text-sm text-slate-600">© <span id="year"></span> SaveWell</div>
   </footer>
-  <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    const menuBtn = document.getElementById('menuBtn');
+    const mobileMenu = document.getElementById('mobileMenu');
+    if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+  </script>
 </body>
 </html>

--- a/payers.html
+++ b/payers.html
@@ -18,7 +18,20 @@
         <a class="text-saveWine font-semibold" href="payers.html">For Payers</a>
         <a class="hover:text-saveWine" href="brokers.html">For Brokers</a>
       </nav>
-      <a href="#" class="inline-flex items-center rounded-xl bg-saveWine px-4 py-2 text-white text-sm font-semibold hover:bg-saveTealDark">Login</a>
+      <div class="flex items-center gap-2">
+        <a href="#" class="inline-flex items-center rounded-xl bg-saveWine px-4 py-2 text-white text-sm font-semibold hover:bg-saveWineDark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-saveWine">Login</a>
+        <button class="md:hidden inline-flex items-center p-2" id="menuBtn" aria-label="Open Menu">
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
+      </div>
+    </div>
+    <!-- Mobile menu -->
+    <div id="mobileMenu" class="md:hidden hidden border-t border-slate-200">
+      <div class="px-4 py-3 space-y-2">
+        <a class="block py-2" href="providers.html">For Providers</a>
+        <a class="block py-2 text-saveWine font-semibold" href="payers.html">For Payers</a>
+        <a class="block py-2" href="brokers.html">For Brokers</a>
+      </div>
     </div>
   </header>
 
@@ -52,6 +65,11 @@
   <footer class="bg-white border-t border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 text-sm text-slate-600">© <span id="year"></span> SaveWell</div>
   </footer>
-  <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    const menuBtn = document.getElementById('menuBtn');
+    const mobileMenu = document.getElementById('mobileMenu');
+    if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+  </script>
 </body>
 </html>

--- a/providers.html
+++ b/providers.html
@@ -19,7 +19,20 @@
         <a class="hover:text-saveWine" href="payers.html">For Payers</a>
         <a class="hover:text-saveWine" href="brokers.html">For Brokers</a>
       </nav>
-      <a href="#" class="inline-flex items-center rounded-xl bg-saveWine px-4 py-2 text-white text-sm font-semibold hover:bg-saveTealDark">Login</a>
+      <div class="flex items-center gap-2">
+        <a href="#" class="inline-flex items-center rounded-xl bg-saveWine px-4 py-2 text-white text-sm font-semibold hover:bg-saveWineDark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-saveWine">Login</a>
+        <button class="md:hidden inline-flex items-center p-2" id="menuBtn" aria-label="Open Menu">
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
+      </div>
+    </div>
+    <!-- Mobile menu -->
+    <div id="mobileMenu" class="md:hidden hidden border-t border-slate-200">
+      <div class="px-4 py-3 space-y-2">
+        <a class="block py-2 text-saveWine font-semibold" href="providers.html">For Providers</a>
+        <a class="block py-2" href="payers.html">For Payers</a>
+        <a class="block py-2" href="brokers.html">For Brokers</a>
+      </div>
     </div>
   </header>
 
@@ -53,6 +66,11 @@
   <footer class="bg-white border-t border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 text-sm text-slate-600">© <span id="year"></span> SaveWell</div>
   </footer>
-  <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    const menuBtn = document.getElementById('menuBtn');
+    const mobileMenu = document.getElementById('mobileMenu');
+    if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+  </script>
 </body>
 </html>

--- a/results.html
+++ b/results.html
@@ -21,7 +21,20 @@
         <a class="hover:text-saveWine" href="payers.html">For Payers</a>
         <a class="hover:text-saveWine" href="brokers.html">For Brokers</a>
       </nav>
-      <a href="#" class="inline-flex items-center rounded-xl bg-saveWine px-4 py-2 text-white text-sm font-semibold hover:bg-saveTealDark">Login</a>
+      <div class="flex items-center gap-2">
+        <a href="#" class="inline-flex items-center rounded-xl bg-saveWine px-4 py-2 text-white text-sm font-semibold hover:bg-saveWineDark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-saveWine">Login</a>
+        <button class="md:hidden inline-flex items-center p-2" id="menuBtn" aria-label="Open Menu">
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
+      </div>
+    </div>
+    <!-- Mobile menu -->
+    <div id="mobileMenu" class="md:hidden hidden border-t border-slate-200">
+      <div class="px-4 py-3 space-y-2">
+        <a class="block py-2" href="providers.html">For Providers</a>
+        <a class="block py-2" href="payers.html">For Payers</a>
+        <a class="block py-2" href="brokers.html">For Brokers</a>
+      </div>
     </div>
   </header>
 
@@ -71,6 +84,10 @@
 
   <script>
     const y = document.getElementById('year'); if (y) y.textContent = new Date().getFullYear();
+
+    const menuBtn = document.getElementById('menuBtn');
+    const mobileMenu = document.getElementById('mobileMenu');
+    if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
     // Demo dataset (static) — replace with real API later
     const DOCTORS = [


### PR DESCRIPTION
## Summary
- replicate index page's responsive menu across providers, payers, brokers, and results pages
- add mobile navigation toggle script to these pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bef7806c83268cb1509e0cf3fb4b