### PR TITLE
refactor: reposition hero image

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
         <p class="mt-3 text-sm text-slate-500">By searching, you agree to our <a class="underline hover:text-saveWine" href="#footer-privacy">Privacy</a> and <a class="underline hover:text-saveWine" href="#footer-terms">Terms</a>.</p>
       </div>
 
-      <img src="assets/hero/pennywise-peter-waist.png" alt="Pennywise Peter" class="hidden lg:block absolute top-0 right-0 w-[346px] pointer-events-none" />
+      <img src="assets/hero/pennywise-peter-waist.png" alt="Pennywise Peter" class="hidden lg:block absolute top-0 right-24 w-[346px] pointer-events-none" />
     </div>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -68,9 +68,9 @@
   </header>
 
   <!-- Hero -->
-  <section class="hero-bg bg-gradient-to-b from-white to-slate-50">
-    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12 lg:py-20 grid lg:grid-cols-2 gap-10 items-center">
-      <div>
+  <section class="relative hero-bg bg-gradient-to-b from-white to-slate-50 overflow-hidden">
+    <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12 lg:py-20">
+      <div class="relative z-10 lg:w-1/2">
         <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight text-slate-900">
           <span class="text-saveWine">Earn rewards</span> for choosing trusted doctors.
         </h1>
@@ -102,13 +102,7 @@
         <p class="mt-3 text-sm text-slate-500">By searching, you agree to our <a class="underline hover:text-saveWine" href="#footer-privacy">Privacy</a> and <a class="underline hover:text-saveWine" href="#footer-terms">Terms</a>.</p>
       </div>
 
-      <!-- Right column image and quote -->
-      <div class="lg:justify-self-end relative mx-10 shadow-lg rounded-3xl">
-        <img src="assets/hero/pennywise-peter-waist.png" alt="Pennywise Peter" class="w-[346px] h-auto rounded-3xl m-10" />
-        <div class="absolute bottom-4 left-1/2 transform -translate-x-1/2 bg-white/90 text-gray-600 p-4 rounded-lg shadow-md italic leading-relaxed max-w-xs">
-          Pennywise Peter saves on his Medigap premium by receiving physical therapy from a SaveWell provider
-        </div>
-      </div>
+      <img src="assets/hero/pennywise-peter-waist.png" alt="Pennywise Peter" class="hidden lg:block absolute top-0 right-0 w-[346px] pointer-events-none" />
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- remove testimonial card and reposition Pennywise Peter image as right-side hero background

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b88ca375008326a03b5c22f4f25c23