### PR TITLE
Copy specialty dropdown to results page

### DIFF
--- a/results.html
+++ b/results.html
@@ -47,13 +47,16 @@
         <form action="results.html" method="get" class="bg-white border rounded-2xl p-3 grid grid-cols-1 sm:grid-cols-5 gap-3">
           <select name="specialty" id="specialty" class="sm:col-span-2 rounded-xl border-slate-300 focus:border-saveWine focus:ring-saveWine py-3">
             <option value="">All specialties</option>
+            <option>Ambulatory Surgical Center</option>
             <option>Cardiology</option>
+            <option>Dermatology</option>
+            <option>Endocrinology</option>
+            <option>Gastroenterology</option>
+            <option>Hematology &amp; Oncology</option>
+            <option>Neurology</option>
+            <option>Obstetrics &amp; Gynecology</option>
+            <option>Orthopedic Surgery</option>
             <option>Rheumatology</option>
-            <option>Skilled Nursing Facility</option>
-            <option>Imaging</option>
-            <option>Physical Therapy</option>
-            <option>Primary Care</option>
-            <option>Orthopedics</option>
           </select>
           <input name="zip" id="zip" placeholder="ZIP code" pattern="\d{5}" class="sm:col-span-2 rounded-xl border-slate-300 focus:border-saveWine focus:ring-saveWine py-3 px-3" />
           <button class="sm:col-span-1 rounded-xl bg-saveTeal text-white font-semibold px-5 py-3 hover:bg-saveTealDark">Search</button>


### PR DESCRIPTION
## Summary
- Mirror index page specialty options on results search dropdown

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b894e0d21483268fb530f44e68733e