### PR TITLE
Add premium savings support

### DIFF
--- a/data/providers.json
+++ b/data/providers.json
@@ -7,7 +7,8 @@
     "city": "WISCONSIN RAPIDS",
     "state": "WI",
     "address": "140 24TH ST S",
-    "phone": "(715) 424-1881"
+    "phone": "(715) 424-1881",
+    "premium_savings": 5
   },
   {
     "id": 2,
@@ -17,7 +18,8 @@
     "city": "RICE LAKE",
     "state": "WI",
     "address": "2200 CEDARCREST DRIVE, SUITE B",
-    "phone": "(586) 864-6006"
+    "phone": "(586) 864-6006",
+    "premium_savings": 10
   },
   {
     "id": 3,
@@ -27,7 +29,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "500 VINCENT STREET, SUITE A",
-    "phone": "(715) 345-0500"
+    "phone": "(715) 345-0500",
+    "premium_savings": 15
   },
   {
     "id": 4,
@@ -37,7 +40,8 @@
     "city": "OCONOMOWOC",
     "state": "WI",
     "address": "1185 CORPORATE CENTER DR, SUITE 125",
-    "phone": "(414) 454-0600"
+    "phone": "(414) 454-0600",
+    "premium_savings": 20
   },
   {
     "id": 5,
@@ -47,7 +51,8 @@
     "city": "BURLINGTON",
     "state": "WI",
     "address": "248 MCHENRY ST",
-    "phone": "(262) 767-8000"
+    "phone": "(262) 767-8000",
+    "premium_savings": 0
   },
   {
     "id": 6,
@@ -57,7 +62,8 @@
     "city": "MARINETTE",
     "state": "WI",
     "address": "1281 MARINETTE AVE",
-    "phone": "(715) 330-7090"
+    "phone": "(715) 330-7090",
+    "premium_savings": 5
   },
   {
     "id": 7,
@@ -67,7 +73,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "3802 OAKWOOD MALL DR",
-    "phone": "(715) 839-9280"
+    "phone": "(715) 839-9280",
+    "premium_savings": 10
   },
   {
     "id": 8,
@@ -77,7 +84,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "744 S WEBSTER AVE, 2ND FLOOR",
-    "phone": "(920) 433-3640"
+    "phone": "(920) 433-3640",
+    "premium_savings": 15
   },
   {
     "id": 9,
@@ -87,7 +95,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY, #840",
-    "phone": "(414) 649-3530"
+    "phone": "(414) 649-3530",
+    "premium_savings": 20
   },
   {
     "id": 10,
@@ -97,7 +106,8 @@
     "city": "MARINETTE",
     "state": "WI",
     "address": "3003 UNIVERSITY DR",
-    "phone": "(715) 735-4200"
+    "phone": "(715) 735-4200",
+    "premium_savings": 0
   },
   {
     "id": 11,
@@ -107,7 +117,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "659 W HAMILTON AVE",
-    "phone": "(715) 831-4444"
+    "phone": "(715) 831-4444",
+    "premium_savings": 5
   },
   {
     "id": 12,
@@ -117,7 +128,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "659 W HAMILTON AVE",
-    "phone": "(715) 831-4444"
+    "phone": "(715) 831-4444",
+    "premium_savings": 10
   },
   {
     "id": 13,
@@ -127,7 +139,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3267 S 16TH ST, SUITE 104",
-    "phone": "(414) 643-8500"
+    "phone": "(414) 643-8500",
+    "premium_savings": 15
   },
   {
     "id": 14,
@@ -137,7 +150,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1400 BELLINGER ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 20
   },
   {
     "id": 15,
@@ -147,7 +161,8 @@
     "city": "OAK CREEK",
     "state": "WI",
     "address": "7901 S 6TH ST",
-    "phone": "(414) 346-8000"
+    "phone": "(414) 346-8000",
+    "premium_savings": 0
   },
   {
     "id": 16,
@@ -157,7 +172,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1400 BELLINGER ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 5
   },
   {
     "id": 17,
@@ -167,7 +183,8 @@
     "city": "MINOCQUA",
     "state": "WI",
     "address": "9601 TOWNLINE RD",
-    "phone": "(715) 358-1000"
+    "phone": "(715) 358-1000",
+    "premium_savings": 10
   },
   {
     "id": 18,
@@ -177,7 +194,8 @@
     "city": "MARSHFIELD",
     "state": "WI",
     "address": "1000 N OAK AVE",
-    "phone": "(715) 387-5511"
+    "phone": "(715) 387-5511",
+    "premium_savings": 15
   },
   {
     "id": 19,
@@ -187,7 +205,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "202 S PARK ST",
-    "phone": "(608) 267-5970"
+    "phone": "(608) 267-5970",
+    "premium_savings": 20
   },
   {
     "id": 20,
@@ -197,7 +216,8 @@
     "city": "WISCONSIN RAPIDS",
     "state": "WI",
     "address": "420 DEWEY ST",
-    "phone": "(715) 421-4500"
+    "phone": "(715) 421-4500",
+    "premium_savings": 0
   },
   {
     "id": 21,
@@ -207,7 +227,8 @@
     "city": "SUMMIT",
     "state": "WI",
     "address": "36500 AURORA DR",
-    "phone": "(262) 434-5000"
+    "phone": "(262) 434-5000",
+    "premium_savings": 5
   },
   {
     "id": 22,
@@ -217,7 +238,8 @@
     "city": "MANITOWOC",
     "state": "WI",
     "address": "1515 RANDOLPH CT",
-    "phone": "(920) 683-5278"
+    "phone": "(920) 683-5278",
+    "premium_savings": 10
   },
   {
     "id": 23,
@@ -227,7 +249,8 @@
     "city": "MARINETTE",
     "state": "WI",
     "address": "3515 MURRAY STREET",
-    "phone": "(715) 732-0699"
+    "phone": "(715) 732-0699",
+    "premium_savings": 15
   },
   {
     "id": 24,
@@ -237,7 +260,8 @@
     "city": "MANITOWOC",
     "state": "WI",
     "address": "801 YORK ST",
-    "phone": "(920) 683-5278"
+    "phone": "(920) 683-5278",
+    "premium_savings": 20
   },
   {
     "id": 25,
@@ -247,7 +271,8 @@
     "city": "BURLINGTON",
     "state": "WI",
     "address": "248 MCHENRY ST",
-    "phone": "(262) 767-8267"
+    "phone": "(262) 767-8267",
+    "premium_savings": 0
   },
   {
     "id": 26,
@@ -257,7 +282,8 @@
     "city": "STURGEON BAY",
     "state": "WI",
     "address": "33 GREEN BAY RD",
-    "phone": "(920) 683-5278"
+    "phone": "(920) 683-5278",
+    "premium_savings": 5
   },
   {
     "id": 27,
@@ -267,7 +293,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "5501A VERN HOLMES DR",
-    "phone": "(715) 849-5333"
+    "phone": "(715) 849-5333",
+    "premium_savings": 10
   },
   {
     "id": 28,
@@ -277,7 +304,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "733 W CLAIREMONT AVE, PEDIATRIC DERMATOLOGY",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 15
   },
   {
     "id": 29,
@@ -287,7 +315,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "2116 CRAIG ROAD",
-    "phone": "(715) 858-4747"
+    "phone": "(715) 858-4747",
+    "premium_savings": 20
   },
   {
     "id": 30,
@@ -297,7 +326,8 @@
     "city": "OCONTO FALLS",
     "state": "WI",
     "address": "835 S MAIN ST, SUITE 1",
-    "phone": "(920) 846-4864"
+    "phone": "(920) 846-4864",
+    "premium_savings": 0
   },
   {
     "id": 31,
@@ -307,7 +337,8 @@
     "city": "SUMMIT",
     "state": "WI",
     "address": "36500 AURORA DR",
-    "phone": "(262) 434-5000"
+    "phone": "(262) 434-5000",
+    "premium_savings": 5
   },
   {
     "id": 32,
@@ -317,7 +348,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "2116 CRAIG RD",
-    "phone": "(715) 858-4500"
+    "phone": "(715) 858-4500",
+    "premium_savings": 10
   },
   {
     "id": 33,
@@ -327,7 +359,8 @@
     "city": "MARSHFIELD",
     "state": "WI",
     "address": "1000 N OAK AVE",
-    "phone": "(715) 387-5511"
+    "phone": "(715) 387-5511",
+    "premium_savings": 15
   },
   {
     "id": 34,
@@ -337,7 +370,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1400 BELLINGER ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 20
   },
   {
     "id": 35,
@@ -347,7 +381,8 @@
     "city": "ASHLAND",
     "state": "WI",
     "address": "1615 MAPLE LN STE 1",
-    "phone": "(715) 685-7500"
+    "phone": "(715) 685-7500",
+    "premium_savings": 0
   },
   {
     "id": 36,
@@ -357,7 +392,8 @@
     "city": "MARSHFIELD",
     "state": "WI",
     "address": "1000 N OAK AVE",
-    "phone": "(715) 387-5511"
+    "phone": "(715) 387-5511",
+    "premium_savings": 5
   },
   {
     "id": 37,
@@ -367,7 +403,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD, SUITE 140",
-    "phone": "(920) 288-8100"
+    "phone": "(920) 288-8100",
+    "premium_savings": 10
   },
   {
     "id": 38,
@@ -377,7 +414,8 @@
     "city": "TWO RIVERS",
     "state": "WI",
     "address": "5300 MEMORIAL DR",
-    "phone": "(920) 793-7548"
+    "phone": "(920) 793-7548",
+    "premium_savings": 15
   },
   {
     "id": 39,
@@ -387,7 +425,8 @@
     "city": "MANITOWOC",
     "state": "WI",
     "address": "1900 WOODLAND DR",
-    "phone": "(920) 320-6212"
+    "phone": "(920) 320-6212",
+    "premium_savings": 20
   },
   {
     "id": 40,
@@ -397,7 +436,8 @@
     "city": "WISCONSIN RAPIDS",
     "state": "WI",
     "address": "420 DEWEY STREET",
-    "phone": "(715) 421-1001"
+    "phone": "(715) 421-1001",
+    "premium_savings": 0
   },
   {
     "id": 41,
@@ -407,7 +447,8 @@
     "city": "SUMMIT",
     "state": "WI",
     "address": "36500 AURORA DR",
-    "phone": "(262) 434-1000"
+    "phone": "(262) 434-1000",
+    "premium_savings": 5
   },
   {
     "id": 42,
@@ -417,7 +458,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1221 WHIPPLE ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 10
   },
   {
     "id": 43,
@@ -427,7 +469,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "1033 N MAYFAIR RD, SUITE 101",
-    "phone": "(414) 454-0600"
+    "phone": "(414) 454-0600",
+    "premium_savings": 15
   },
   {
     "id": 44,
@@ -437,7 +480,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 20
   },
   {
     "id": 45,
@@ -447,7 +491,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6615"
+    "phone": "(414) 908-6615",
+    "premium_savings": 0
   },
   {
     "id": 46,
@@ -457,7 +502,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "411 WESTWOOD DR",
-    "phone": "(715) 847-2558"
+    "phone": "(715) 847-2558",
+    "premium_savings": 5
   },
   {
     "id": 47,
@@ -467,7 +513,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1211 FISH HATCHERY RD.",
-    "phone": "(608) 252-8000"
+    "phone": "(608) 252-8000",
+    "premium_savings": 10
   },
   {
     "id": 48,
@@ -477,7 +524,8 @@
     "city": "PLEASANT PRAIRIE",
     "state": "WI",
     "address": "9555 76TH ST STE 1200",
-    "phone": "(262) 671-7300"
+    "phone": "(262) 671-7300",
+    "premium_savings": 15
   },
   {
     "id": 49,
@@ -487,7 +535,8 @@
     "city": "MARINETTE",
     "state": "WI",
     "address": "3003 UNIVERSITY DR",
-    "phone": "(715) 735-4200"
+    "phone": "(715) 735-4200",
+    "premium_savings": 20
   },
   {
     "id": 50,
@@ -497,7 +546,8 @@
     "city": "GRAFTON",
     "state": "WI",
     "address": "975 PORT WASHINGTON RD",
-    "phone": "(262) 329-5000"
+    "phone": "(262) 329-5000",
+    "premium_savings": 0
   },
   {
     "id": 51,
@@ -507,7 +557,8 @@
     "city": "MARSHFIELD",
     "state": "WI",
     "address": "1000 N OAK AVE",
-    "phone": "(715) 387-5426"
+    "phone": "(715) 387-5426",
+    "premium_savings": 5
   },
   {
     "id": 52,
@@ -517,7 +568,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "900 W CLAIREMONT AVE",
-    "phone": "(715) 839-3956"
+    "phone": "(715) 839-3956",
+    "premium_savings": 10
   },
   {
     "id": 53,
@@ -527,7 +579,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-3000"
+    "phone": "(414) 805-3000",
+    "premium_savings": 15
   },
   {
     "id": 54,
@@ -537,7 +590,8 @@
     "city": "RICE LAKE",
     "state": "WI",
     "address": "1700 W. STOUT ST.",
-    "phone": "(715) 236-8100"
+    "phone": "(715) 236-8100",
+    "premium_savings": 20
   },
   {
     "id": 55,
@@ -547,7 +601,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "3506 OAKWOOD MALL DR STE A",
-    "phone": "(715) 831-0811"
+    "phone": "(715) 831-0811",
+    "premium_savings": 0
   },
   {
     "id": 56,
@@ -557,7 +612,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 5
   },
   {
     "id": 57,
@@ -567,7 +623,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "950 W CLAIREMONT AVE, SUITE B",
-    "phone": "(715) 831-0811"
+    "phone": "(715) 831-0811",
+    "premium_savings": 10
   },
   {
     "id": 58,
@@ -577,7 +634,8 @@
     "city": "SUMMIT",
     "state": "WI",
     "address": "36500 AURORA DR",
-    "phone": "(262) 434-5000"
+    "phone": "(262) 434-5000",
+    "premium_savings": 15
   },
   {
     "id": 59,
@@ -587,7 +645,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1400 BELLINGER ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 20
   },
   {
     "id": 60,
@@ -597,7 +656,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1400 BELLINGER ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 0
   },
   {
     "id": 61,
@@ -607,7 +667,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "1111 DELAFIELD ST STE 105",
-    "phone": "(262) 542-9503"
+    "phone": "(262) 542-9503",
+    "premium_savings": 5
   },
   {
     "id": 62,
@@ -617,7 +678,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "733 W CLAIREMONT AVE",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 10
   },
   {
     "id": 63,
@@ -627,7 +689,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 15
   },
   {
     "id": 64,
@@ -637,7 +700,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1221 WHIPPLE ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 20
   },
   {
     "id": 65,
@@ -647,7 +711,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "2116 CRAIG ROAD",
-    "phone": "(715) 858-4630"
+    "phone": "(715) 858-4630",
+    "premium_savings": 0
   },
   {
     "id": 66,
@@ -657,7 +722,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "824 ILLINOIS AVENUE",
-    "phone": "(715) 342-7500"
+    "phone": "(715) 342-7500",
+    "premium_savings": 5
   },
   {
     "id": 67,
@@ -667,7 +733,8 @@
     "city": "BARABOO",
     "state": "WI",
     "address": "1700 TUTTLE ST.",
-    "phone": "(608) 355-3800"
+    "phone": "(608) 355-3800",
+    "premium_savings": 10
   },
   {
     "id": 68,
@@ -677,7 +744,8 @@
     "city": "LAKE GENEVA",
     "state": "WI",
     "address": "146 E GENEVA SQ",
-    "phone": "(262) 249-5005"
+    "phone": "(262) 249-5005",
+    "premium_savings": 15
   },
   {
     "id": 69,
@@ -687,7 +755,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1400 BELLINGER ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 20
   },
   {
     "id": 70,
@@ -697,7 +766,8 @@
     "city": "MAUSTON",
     "state": "WI",
     "address": "1040 DIVISION ST",
-    "phone": "(608) 847-5000"
+    "phone": "(608) 847-5000",
+    "premium_savings": 0
   },
   {
     "id": 71,
@@ -707,7 +777,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "3213 STEIN BLVD",
-    "phone": "(715) 836-9242"
+    "phone": "(715) 836-9242",
+    "premium_savings": 5
   },
   {
     "id": 72,
@@ -717,7 +788,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1400 BELLINGER ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 10
   },
   {
     "id": 73,
@@ -727,7 +799,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "500 VINCENT ST",
-    "phone": "(715) 344-0701"
+    "phone": "(715) 344-0701",
+    "premium_savings": 15
   },
   {
     "id": 74,
@@ -737,7 +810,8 @@
     "city": "MARSHFIELD",
     "state": "WI",
     "address": "1000 N OAK AVE",
-    "phone": "(715) 387-5202"
+    "phone": "(715) 387-5202",
+    "premium_savings": 20
   },
   {
     "id": 75,
@@ -747,7 +821,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "500 VINCENT ST",
-    "phone": "(715) 344-0701"
+    "phone": "(715) 344-0701",
+    "premium_savings": 0
   },
   {
     "id": 76,
@@ -757,7 +832,8 @@
     "city": "SUMMIT",
     "state": "WI",
     "address": "36500 AURORA DR",
-    "phone": "(262) 434-1000"
+    "phone": "(262) 434-1000",
+    "premium_savings": 5
   },
   {
     "id": 77,
@@ -767,7 +843,8 @@
     "city": "BURLINGTON",
     "state": "WI",
     "address": "709 SPRING VALLEY RD",
-    "phone": "(262) 767-6020"
+    "phone": "(262) 767-6020",
+    "premium_savings": 10
   },
   {
     "id": 78,
@@ -777,7 +854,8 @@
     "city": "BEAVER DAM",
     "state": "WI",
     "address": "118 W MAPLE AVE",
-    "phone": "(920) 356-1000"
+    "phone": "(920) 356-1000",
+    "premium_savings": 15
   },
   {
     "id": 79,
@@ -787,7 +865,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "500 VINCENT ST",
-    "phone": "(715) 997-9813"
+    "phone": "(715) 997-9813",
+    "premium_savings": 20
   },
   {
     "id": 80,
@@ -797,7 +876,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "500 VINCENT ST",
-    "phone": "(715) 344-0701"
+    "phone": "(715) 344-0701",
+    "premium_savings": 0
   },
   {
     "id": 81,
@@ -807,7 +887,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1400 BELLINGER ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 5
   },
   {
     "id": 82,
@@ -817,7 +898,8 @@
     "city": "SUMMIT",
     "state": "WI",
     "address": "36500 AURORA DR",
-    "phone": "(262) 434-1000"
+    "phone": "(262) 434-1000",
+    "premium_savings": 10
   },
   {
     "id": 83,
@@ -827,7 +909,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2400 E CAPITOL DR",
-    "phone": "(920) 831-5050"
+    "phone": "(920) 831-5050",
+    "premium_savings": 15
   },
   {
     "id": 84,
@@ -837,7 +920,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "500 VINCENT ST",
-    "phone": "(715) 344-0701"
+    "phone": "(715) 344-0701",
+    "premium_savings": 20
   },
   {
     "id": 85,
@@ -847,7 +931,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "500 VINCENT ST",
-    "phone": "(715) 344-0701"
+    "phone": "(715) 344-0701",
+    "premium_savings": 0
   },
   {
     "id": 86,
@@ -857,7 +942,8 @@
     "city": "WISCONSIN RAPIDS",
     "state": "WI",
     "address": "140 24TH ST S",
-    "phone": "(715) 424-1881"
+    "phone": "(715) 424-1881",
+    "premium_savings": 5
   },
   {
     "id": 87,
@@ -867,7 +953,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-7400"
+    "phone": "(414) 805-7400",
+    "premium_savings": 10
   },
   {
     "id": 88,
@@ -877,7 +964,8 @@
     "city": "HARTFORD",
     "state": "WI",
     "address": "1640 E SUMNER ST",
-    "phone": "(262) 670-4000"
+    "phone": "(262) 670-4000",
+    "premium_savings": 15
   },
   {
     "id": 89,
@@ -887,7 +975,8 @@
     "city": "VIROQUA",
     "state": "WI",
     "address": "407 S MAIN ST",
-    "phone": "(608) 637-3195"
+    "phone": "(608) 637-3195",
+    "premium_savings": 20
   },
   {
     "id": 90,
@@ -897,7 +986,8 @@
     "city": "STEVENS POINT",
     "state": "WI",
     "address": "500 VINCENT ST",
-    "phone": "(715) 344-0701"
+    "phone": "(715) 344-0701",
+    "premium_savings": 0
   },
   {
     "id": 91,
@@ -907,7 +997,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "2501 W BELTLINE HWY STE 601",
-    "phone": "(608) 234-7436"
+    "phone": "(608) 234-7436",
+    "premium_savings": 5
   },
   {
     "id": 92,
@@ -917,7 +1008,8 @@
     "city": "MANITOWOC",
     "state": "WI",
     "address": "1111 BAYSHORE DR",
-    "phone": "(920) 682-6376"
+    "phone": "(920) 682-6376",
+    "premium_savings": 10
   },
   {
     "id": 93,
@@ -927,7 +1019,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 15
   },
   {
     "id": 94,
@@ -937,7 +1030,8 @@
     "city": "MANITOWOC",
     "state": "WI",
     "address": "1111 BAYSHORE DR",
-    "phone": "(920) 682-6376"
+    "phone": "(920) 682-6376",
+    "premium_savings": 20
   },
   {
     "id": 95,
@@ -947,7 +1041,8 @@
     "city": "MARSHFIELD",
     "state": "WI",
     "address": "1000 N OAK AVE",
-    "phone": "(715) 387-5511"
+    "phone": "(715) 387-5511",
+    "premium_savings": 0
   },
   {
     "id": 96,
@@ -957,7 +1052,8 @@
     "city": "STURGEON BAY",
     "state": "WI",
     "address": "323 S 18TH AVE",
-    "phone": "(920) 746-0510"
+    "phone": "(920) 746-0510",
+    "premium_savings": 5
   },
   {
     "id": 97,
@@ -967,7 +1063,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "5320 W MICHAELS DR",
-    "phone": "(920) 882-8200"
+    "phone": "(920) 882-8200",
+    "premium_savings": 10
   },
   {
     "id": 98,
@@ -977,7 +1074,8 @@
     "city": "WATERTOWN",
     "state": "WI",
     "address": "123 HOSPITAL DR, SUITE 1008",
-    "phone": "(920) 206-6500"
+    "phone": "(920) 206-6500",
+    "premium_savings": 15
   },
   {
     "id": 99,
@@ -987,7 +1085,8 @@
     "city": "WISCONSIN RAPIDS",
     "state": "WI",
     "address": "140 24TH ST S",
-    "phone": "(715) 424-1881"
+    "phone": "(715) 424-1881",
+    "premium_savings": 20
   },
   {
     "id": 100,
@@ -997,7 +1096,8 @@
     "city": "BEAVER DAM",
     "state": "WI",
     "address": "705 S UNIVERSITY AVE STE 150",
-    "phone": "(920) 219-4009"
+    "phone": "(920) 219-4009",
+    "premium_savings": 0
   },
   {
     "id": 101,
@@ -1007,7 +1107,8 @@
     "city": "VIROQUA",
     "state": "WI",
     "address": "407 S MAIN ST",
-    "phone": "(608) 637-3195"
+    "phone": "(608) 637-3195",
+    "premium_savings": 5
   },
   {
     "id": 102,
@@ -1017,7 +1118,8 @@
     "city": "MAUSTON",
     "state": "WI",
     "address": "1040 DIVISION ST",
-    "phone": "(608) 847-5000"
+    "phone": "(608) 847-5000",
+    "premium_savings": 10
   },
   {
     "id": 103,
@@ -1027,7 +1129,8 @@
     "city": "MAUSTON",
     "state": "WI",
     "address": "1040 DIVISION ST",
-    "phone": "(608) 847-5000"
+    "phone": "(608) 847-5000",
+    "premium_savings": 15
   },
   {
     "id": 104,
@@ -1037,7 +1140,8 @@
     "city": "PORTAGE",
     "state": "WI",
     "address": "2817 NEW PINERY RD",
-    "phone": "(608) 742-4131"
+    "phone": "(608) 742-4131",
+    "premium_savings": 20
   },
   {
     "id": 105,
@@ -1047,7 +1151,8 @@
     "city": "STOUGHTON",
     "state": "WI",
     "address": "225 CHURCH ST, DEAN MEDICAL CENTER",
-    "phone": "(608) 877-2700"
+    "phone": "(608) 877-2700",
+    "premium_savings": 0
   },
   {
     "id": 106,
@@ -1057,7 +1162,8 @@
     "city": "RHINELANDER",
     "state": "WI",
     "address": "2251 N SHORE DR",
-    "phone": "(715) 361-4700"
+    "phone": "(715) 361-4700",
+    "premium_savings": 5
   },
   {
     "id": 107,
@@ -1067,7 +1173,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD, 1ST FLOOR",
-    "phone": "(920) 288-8100"
+    "phone": "(920) 288-8100",
+    "premium_savings": 10
   },
   {
     "id": 108,
@@ -1077,7 +1184,8 @@
     "city": "WATERFORD",
     "state": "WI",
     "address": "818 FOREST LN",
-    "phone": "(262) 514-3700"
+    "phone": "(262) 514-3700",
+    "premium_savings": 15
   },
   {
     "id": 109,
@@ -1087,7 +1195,8 @@
     "city": "MARSHFIELD",
     "state": "WI",
     "address": "1000 N OAK AVE",
-    "phone": "(715) 387-5682"
+    "phone": "(715) 387-5682",
+    "premium_savings": 20
   },
   {
     "id": 110,
@@ -1097,7 +1206,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "250 N METRO DR",
-    "phone": "(920) 830-2020"
+    "phone": "(920) 830-2020",
+    "premium_savings": 0
   },
   {
     "id": 111,
@@ -1107,7 +1217,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2105 E. ENTERPRISE AVE., SUITE 101",
-    "phone": "(920) 560-1100"
+    "phone": "(920) 560-1100",
+    "premium_savings": 5
   },
   {
     "id": 112,
@@ -1117,7 +1228,8 @@
     "city": "KAUKAUNA",
     "state": "WI",
     "address": "1500 ARBOR WAY",
-    "phone": "(920) 372-7150"
+    "phone": "(920) 372-7150",
+    "premium_savings": 10
   },
   {
     "id": 113,
@@ -1127,7 +1239,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2325 N CASALOMA DR",
-    "phone": "(920) 730-2885"
+    "phone": "(920) 730-2885",
+    "premium_savings": 15
   },
   {
     "id": 114,
@@ -1137,7 +1250,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "4652 S BILTMORE LN",
-    "phone": "(608) 924-5655"
+    "phone": "(608) 924-5655",
+    "premium_savings": 20
   },
   {
     "id": 115,
@@ -1147,7 +1261,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "1818 N MEADE ST",
-    "phone": "(920) 731-8900"
+    "phone": "(920) 731-8900",
+    "premium_savings": 0
   },
   {
     "id": 116,
@@ -1157,7 +1272,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "5045 W GRANDE MARKET DR",
-    "phone": "(920) 886-9380"
+    "phone": "(920) 886-9380",
+    "premium_savings": 5
   },
   {
     "id": 117,
@@ -1167,7 +1283,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "5045 W GRANDE MARKET DR",
-    "phone": "(920) 886-9380"
+    "phone": "(920) 886-9380",
+    "premium_savings": 10
   },
   {
     "id": 118,
@@ -1177,7 +1294,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "5045 W GRANDE MARKET DR",
-    "phone": "(920) 886-9380"
+    "phone": "(920) 886-9380",
+    "premium_savings": 15
   },
   {
     "id": 119,
@@ -1187,7 +1305,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "100 W LAWRENCE ST, SUITE 409",
-    "phone": "(920) 733-5138"
+    "phone": "(920) 733-5138",
+    "premium_savings": 20
   },
   {
     "id": 120,
@@ -1197,7 +1316,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "3935 N LIGHTNING DR",
-    "phone": "(920) 968-1790"
+    "phone": "(920) 968-1790",
+    "premium_savings": 0
   },
   {
     "id": 121,
@@ -1207,7 +1327,8 @@
     "city": "MENASHA",
     "state": "WI",
     "address": "1550 MIDWAY PL",
-    "phone": "(920) 727-8030"
+    "phone": "(920) 727-8030",
+    "premium_savings": 5
   },
   {
     "id": 122,
@@ -1217,7 +1338,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2500 E CAPITOL DR STE 1700",
-    "phone": "(920) 731-8131"
+    "phone": "(920) 731-8131",
+    "premium_savings": 10
   },
   {
     "id": 123,
@@ -1227,7 +1349,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2500 E CAPITOL DR",
-    "phone": "(920) 364-3600"
+    "phone": "(920) 364-3600",
+    "premium_savings": 15
   },
   {
     "id": 124,
@@ -1237,7 +1360,8 @@
     "city": "WESTON",
     "state": "WI",
     "address": "3301 CRANBERRY BLVD",
-    "phone": "(715) 393-3900"
+    "phone": "(715) 393-3900",
+    "premium_savings": 20
   },
   {
     "id": 125,
@@ -1247,7 +1371,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2500 E CAPITOL DR",
-    "phone": "(920) 364-3600"
+    "phone": "(920) 364-3600",
+    "premium_savings": 0
   },
   {
     "id": 126,
@@ -1257,7 +1382,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "1818 N MEADE ST",
-    "phone": "(920) 749-4000"
+    "phone": "(920) 749-4000",
+    "premium_savings": 5
   },
   {
     "id": 127,
@@ -1267,7 +1393,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2105 E ENTERPRISE AVE",
-    "phone": "(920) 560-1000"
+    "phone": "(920) 560-1000",
+    "premium_savings": 10
   },
   {
     "id": 128,
@@ -1277,7 +1404,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2323 N CASALOMA DR",
-    "phone": "(920) 730-8833"
+    "phone": "(920) 730-8833",
+    "premium_savings": 15
   },
   {
     "id": 129,
@@ -1287,7 +1415,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2105 E ENTERPRISE AVE, STE 111",
-    "phone": "(920) 731-6611"
+    "phone": "(920) 731-6611",
+    "premium_savings": 20
   },
   {
     "id": 130,
@@ -1297,7 +1426,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2105 E ENTERPRISE AVE # 111",
-    "phone": "(920) 731-6611"
+    "phone": "(920) 731-6611",
+    "premium_savings": 0
   },
   {
     "id": 131,
@@ -1307,7 +1437,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2105 E ENTERPRISE AVE",
-    "phone": "(920) 560-1000"
+    "phone": "(920) 560-1000",
+    "premium_savings": 5
   },
   {
     "id": 132,
@@ -1317,7 +1448,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "820 E GRANT ST",
-    "phone": "(920) 831-5050"
+    "phone": "(920) 831-5050",
+    "premium_savings": 10
   },
   {
     "id": 133,
@@ -1327,7 +1459,8 @@
     "city": "NEENAH",
     "state": "WI",
     "address": "1205 W AMERICAN DR",
-    "phone": "(920) 430-8113"
+    "phone": "(920) 430-8113",
+    "premium_savings": 15
   },
   {
     "id": 134,
@@ -1337,7 +1470,8 @@
     "city": "CHIPPEWA FALLS",
     "state": "WI",
     "address": "2751 COMMERCIAL BLVD, SUITE 7",
-    "phone": "(715) 797-8310"
+    "phone": "(715) 797-8310",
+    "premium_savings": 20
   },
   {
     "id": 135,
@@ -1347,7 +1481,8 @@
     "city": "ALTOONA",
     "state": "WI",
     "address": "1470 RIVERS EDGE TRL STE B",
-    "phone": "(715) 379-8718"
+    "phone": "(715) 379-8718",
+    "premium_savings": 0
   },
   {
     "id": 136,
@@ -1357,7 +1492,8 @@
     "city": "CHIPPEWA FALLS",
     "state": "WI",
     "address": "855 LAKELAND DR",
-    "phone": "(715) 839-9280"
+    "phone": "(715) 839-9280",
+    "premium_savings": 5
   },
   {
     "id": 137,
@@ -1367,7 +1503,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 10
   },
   {
     "id": 138,
@@ -1377,7 +1514,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "714 W HAMILTON AVE",
-    "phone": "(715) 830-9990"
+    "phone": "(715) 830-9990",
+    "premium_savings": 15
   },
   {
     "id": 139,
@@ -1387,7 +1525,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "714 W HAMILTON AVE",
-    "phone": "(715) 830-9990"
+    "phone": "(715) 830-9990",
+    "premium_savings": 20
   },
   {
     "id": 140,
@@ -1397,7 +1536,8 @@
     "city": "ALTOONA",
     "state": "WI",
     "address": "1200 OAKLEAF WAY, SUITE A",
-    "phone": "(715) 832-1400"
+    "phone": "(715) 832-1400",
+    "premium_savings": 0
   },
   {
     "id": 141,
@@ -1407,7 +1547,8 @@
     "city": "ALTOONA",
     "state": "WI",
     "address": "1200 OAKLEAF WAY, SUITE A",
-    "phone": "(715) 832-1400"
+    "phone": "(715) 832-1400",
+    "premium_savings": 5
   },
   {
     "id": 142,
@@ -1417,7 +1558,8 @@
     "city": "ALTOONA",
     "state": "WI",
     "address": "1200 OAKLEAF WAY STE A",
-    "phone": "(715) 832-1400"
+    "phone": "(715) 832-1400",
+    "premium_savings": 10
   },
   {
     "id": 143,
@@ -1427,7 +1569,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 15
   },
   {
     "id": 144,
@@ -1437,7 +1580,8 @@
     "city": "ALTOONA",
     "state": "WI",
     "address": "1200 OAKLEAF WAY, SUITE A",
-    "phone": "(715) 832-1400"
+    "phone": "(715) 832-1400",
+    "premium_savings": 20
   },
   {
     "id": 145,
@@ -1447,7 +1591,8 @@
     "city": "CHILTON",
     "state": "WI",
     "address": "451 E BROOKLYN ST, STE. 5",
-    "phone": "(920) 849-2100"
+    "phone": "(920) 849-2100",
+    "premium_savings": 0
   },
   {
     "id": 146,
@@ -1457,7 +1602,8 @@
     "city": "WEST BEND",
     "state": "WI",
     "address": "2102 CONTINENTAL DR",
-    "phone": "(262) 558-4367"
+    "phone": "(262) 558-4367",
+    "premium_savings": 5
   },
   {
     "id": 147,
@@ -1467,7 +1613,8 @@
     "city": "FOND DU LAC",
     "state": "WI",
     "address": "420 E DIVISION ST",
-    "phone": "(920) 926-8570"
+    "phone": "(920) 926-8570",
+    "premium_savings": 10
   },
   {
     "id": 148,
@@ -1477,7 +1624,8 @@
     "city": "FOND DU LAC",
     "state": "WI",
     "address": "420 E DIVISION ST",
-    "phone": "(920) 926-8570"
+    "phone": "(920) 926-8570",
+    "premium_savings": 15
   },
   {
     "id": 149,
@@ -1487,7 +1635,8 @@
     "city": "FOND DU LAC",
     "state": "WI",
     "address": "480 E DIVISION ST",
-    "phone": "(920) 926-4100"
+    "phone": "(920) 926-4100",
+    "premium_savings": 20
   },
   {
     "id": 150,
@@ -1497,7 +1646,8 @@
     "city": "FOND DU LAC",
     "state": "WI",
     "address": "421 CAMELOT DR",
-    "phone": "(920) 926-8616"
+    "phone": "(920) 926-8616",
+    "premium_savings": 0
   },
   {
     "id": 151,
@@ -1507,7 +1657,8 @@
     "city": "FOND DU LAC",
     "state": "WI",
     "address": "421 CAMELOT DR",
-    "phone": "(920) 926-8616"
+    "phone": "(920) 926-8616",
+    "premium_savings": 5
   },
   {
     "id": 152,
@@ -1517,7 +1668,8 @@
     "city": "WAUPUN",
     "state": "WI",
     "address": "608 W BROWN ST",
-    "phone": "(920) 324-6802"
+    "phone": "(920) 324-6802",
+    "premium_savings": 10
   },
   {
     "id": 153,
@@ -1527,7 +1679,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "1531 S MADISON ST",
-    "phone": "(920) 996-3700"
+    "phone": "(920) 996-3700",
+    "premium_savings": 15
   },
   {
     "id": 154,
@@ -1537,7 +1690,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD STE 310",
-    "phone": "(920) 288-8300"
+    "phone": "(920) 288-8300",
+    "premium_savings": 20
   },
   {
     "id": 155,
@@ -1547,7 +1701,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD STE 310",
-    "phone": "(920) 288-8300"
+    "phone": "(920) 288-8300",
+    "premium_savings": 0
   },
   {
     "id": 156,
@@ -1557,7 +1712,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1821 S WEBSTER AVE",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 5
   },
   {
     "id": 157,
@@ -1567,7 +1723,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1727 SHAWANO AVE",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 10
   },
   {
     "id": 158,
@@ -1577,7 +1734,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1727 SHAWANO AVE, STE 201",
-    "phone": "(920) 272-1050"
+    "phone": "(920) 272-1050",
+    "premium_savings": 15
   },
   {
     "id": 159,
@@ -1587,7 +1745,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "744 S WEBSTER AVE",
-    "phone": "(920) 433-3640"
+    "phone": "(920) 433-3640",
+    "premium_savings": 20
   },
   {
     "id": 160,
@@ -1597,7 +1756,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1727 SHAWANO AVE, SUITE 201",
-    "phone": "(920) 496-8877"
+    "phone": "(920) 496-8877",
+    "premium_savings": 0
   },
   {
     "id": 161,
@@ -1607,7 +1767,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "744 S WEBSTER AVE, 2ND FLOOR",
-    "phone": "(920) 433-3640"
+    "phone": "(920) 433-3640",
+    "premium_savings": 5
   },
   {
     "id": 162,
@@ -1617,7 +1778,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "744 S WEBSTER AVE FL 2",
-    "phone": "(920) 433-3640"
+    "phone": "(920) 433-3640",
+    "premium_savings": 10
   },
   {
     "id": 163,
@@ -1627,7 +1789,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD, STE 310",
-    "phone": "(920) 288-8300"
+    "phone": "(920) 288-8300",
+    "premium_savings": 15
   },
   {
     "id": 164,
@@ -1637,7 +1800,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD",
-    "phone": "(920) 288-8300"
+    "phone": "(920) 288-8300",
+    "premium_savings": 20
   },
   {
     "id": 165,
@@ -1647,7 +1811,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD",
-    "phone": "(920) 288-8000"
+    "phone": "(920) 288-8000",
+    "premium_savings": 0
   },
   {
     "id": 166,
@@ -1657,7 +1822,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD",
-    "phone": "(920) 288-8100"
+    "phone": "(920) 288-8100",
+    "premium_savings": 5
   },
   {
     "id": 167,
@@ -1667,7 +1833,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 10
   },
   {
     "id": 168,
@@ -1677,7 +1844,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD",
-    "phone": "(920) 288-8100"
+    "phone": "(920) 288-8100",
+    "premium_savings": 15
   },
   {
     "id": 169,
@@ -1687,7 +1855,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2021 S WEBSTER AVE",
-    "phone": "(920) 965-0345"
+    "phone": "(920) 965-0345",
+    "premium_savings": 20
   },
   {
     "id": 170,
@@ -1697,7 +1866,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2806 RIVERVIEW DR",
-    "phone": "(920) 498-7546"
+    "phone": "(920) 498-7546",
+    "premium_savings": 0
   },
   {
     "id": 171,
@@ -1707,7 +1877,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2806 RIVERVIEW DR",
-    "phone": "(920) 498-7546"
+    "phone": "(920) 498-7546",
+    "premium_savings": 5
   },
   {
     "id": 172,
@@ -1717,7 +1888,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD",
-    "phone": "(920) 288-8000"
+    "phone": "(920) 288-8000",
+    "premium_savings": 10
   },
   {
     "id": 173,
@@ -1727,7 +1899,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "720 S VANBUREN ST, SUITE 104",
-    "phone": "(920) 433-6050"
+    "phone": "(920) 433-6050",
+    "premium_savings": 15
   },
   {
     "id": 174,
@@ -1737,7 +1910,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1860 SHAWANO AVE",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 20
   },
   {
     "id": 175,
@@ -1747,7 +1921,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "725 S WEBSTER AVE",
-    "phone": "(920) 431-5650"
+    "phone": "(920) 431-5650",
+    "premium_savings": 0
   },
   {
     "id": 176,
@@ -1757,7 +1932,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "725 S WEBSTER AVE STE 303",
-    "phone": "(920) 431-5650"
+    "phone": "(920) 431-5650",
+    "premium_savings": 5
   },
   {
     "id": 177,
@@ -1767,7 +1943,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1726 SHAWANO AVE",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 10
   },
   {
     "id": 178,
@@ -1777,7 +1954,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "725 S WEBSTER AVE",
-    "phone": "(920) 431-5650"
+    "phone": "(920) 431-5650",
+    "premium_savings": 15
   },
   {
     "id": 179,
@@ -1787,7 +1965,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD",
-    "phone": "(920) 288-8100"
+    "phone": "(920) 288-8100",
+    "premium_savings": 20
   },
   {
     "id": 180,
@@ -1797,7 +1976,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1580 COMMANCHE AVE",
-    "phone": "(920) 435-8326"
+    "phone": "(920) 435-8326",
+    "premium_savings": 0
   },
   {
     "id": 181,
@@ -1807,7 +1987,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1580 COMMANCHE AVE",
-    "phone": "(920) 435-8326"
+    "phone": "(920) 435-8326",
+    "premium_savings": 5
   },
   {
     "id": 182,
@@ -1817,7 +1998,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1580 COMMANCHE AVE",
-    "phone": "(920) 435-8326"
+    "phone": "(920) 435-8326",
+    "premium_savings": 10
   },
   {
     "id": 183,
@@ -1827,7 +2009,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD",
-    "phone": "(920) 288-8000"
+    "phone": "(920) 288-8000",
+    "premium_savings": 15
   },
   {
     "id": 184,
@@ -1837,7 +2020,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2845 GREENBRIER RD",
-    "phone": "(920) 288-8000"
+    "phone": "(920) 288-8000",
+    "premium_savings": 20
   },
   {
     "id": 185,
@@ -1847,7 +2031,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1726 SHAWANO AVE",
-    "phone": "(920) 884-3135"
+    "phone": "(920) 884-3135",
+    "premium_savings": 0
   },
   {
     "id": 186,
@@ -1857,7 +2042,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1821 S WEBSTER AVE",
-    "phone": "(920) 497-4600"
+    "phone": "(920) 497-4600",
+    "premium_savings": 5
   },
   {
     "id": 187,
@@ -1867,7 +2053,8 @@
     "city": "MARINETTE",
     "state": "WI",
     "address": "3130 SHORE DR STE 111, BAY AREA NEUROLOGY CONSULTATNTS",
-    "phone": "(715) 732-8212"
+    "phone": "(715) 732-8212",
+    "premium_savings": 10
   },
   {
     "id": 188,
@@ -1877,7 +2064,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1821 S WEBSTER AVE",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 15
   },
   {
     "id": 189,
@@ -1887,7 +2075,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "1000 MINERAL POINT AVE",
-    "phone": "(608) 756-6000"
+    "phone": "(608) 756-6000",
+    "premium_savings": 20
   },
   {
     "id": 190,
@@ -1897,7 +2086,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "725 S WEBSTER SUITE 201, NEUROLOGY CONSULTANTS",
-    "phone": "(920) 430-7100"
+    "phone": "(920) 430-7100",
+    "premium_savings": 0
   },
   {
     "id": 191,
@@ -1907,7 +2097,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1726 SHAWANO AVE",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 5
   },
   {
     "id": 192,
@@ -1917,7 +2108,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2502 S. ASHLAND AVE.",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 10
   },
   {
     "id": 193,
@@ -1927,7 +2119,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "820 E GRANT ST, THEDACARE ORTHOPEDICS PLUS - AMC",
-    "phone": "(920) 831-5050"
+    "phone": "(920) 831-5050",
+    "premium_savings": 15
   },
   {
     "id": 194,
@@ -1937,7 +2130,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "835 S VAN BUREN ST",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 20
   },
   {
     "id": 195,
@@ -1947,7 +2141,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1970 S RIDGE RD",
-    "phone": "(920) 430-4888"
+    "phone": "(920) 430-4888",
+    "premium_savings": 0
   },
   {
     "id": 196,
@@ -1957,7 +2152,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2223 LIME KILN RD, SUITE 1",
-    "phone": "(920) 468-0246"
+    "phone": "(920) 468-0246",
+    "premium_savings": 5
   },
   {
     "id": 197,
@@ -1967,7 +2163,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2223 LIME KILN RD STE 1",
-    "phone": "(920) 430-8113"
+    "phone": "(920) 430-8113",
+    "premium_savings": 10
   },
   {
     "id": 198,
@@ -1977,7 +2174,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2223 LIME KILN RD, SUITE 1",
-    "phone": "(920) 430-8120"
+    "phone": "(920) 430-8120",
+    "premium_savings": 15
   },
   {
     "id": 199,
@@ -1987,7 +2185,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1110 KEPLER DR",
-    "phone": "(920) 288-5555"
+    "phone": "(920) 288-5555",
+    "premium_savings": 20
   },
   {
     "id": 200,
@@ -1997,7 +2196,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1726 SHAWANO AVE",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 0
   },
   {
     "id": 201,
@@ -2007,7 +2207,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2223 LIME KILN RD, SUITE 1",
-    "phone": "(920) 430-8120"
+    "phone": "(920) 430-8120",
+    "premium_savings": 5
   },
   {
     "id": 202,
@@ -2017,7 +2218,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1970 S RIDGE RD",
-    "phone": "(920) 430-4888"
+    "phone": "(920) 430-4888",
+    "premium_savings": 10
   },
   {
     "id": 203,
@@ -2027,7 +2229,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1110 KEPLER DR",
-    "phone": "(920) 288-5555"
+    "phone": "(920) 288-5555",
+    "premium_savings": 15
   },
   {
     "id": 204,
@@ -2037,7 +2240,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "900 S WEBSTER AVE",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 20
   },
   {
     "id": 205,
@@ -2047,7 +2251,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2223 LIME KILN RD STE 1",
-    "phone": "(920) 430-8113"
+    "phone": "(920) 430-8113",
+    "premium_savings": 0
   },
   {
     "id": 206,
@@ -2057,7 +2262,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1970 S RIDGE RD",
-    "phone": "(920) 430-4888"
+    "phone": "(920) 430-4888",
+    "premium_savings": 5
   },
   {
     "id": 207,
@@ -2067,7 +2273,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2223 LIME KILN RD STE 1",
-    "phone": "(920) 430-8113"
+    "phone": "(920) 430-8113",
+    "premium_savings": 10
   },
   {
     "id": 208,
@@ -2077,7 +2284,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "3113 SAEMANN AVE",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 15
   },
   {
     "id": 209,
@@ -2087,7 +2295,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "1715 DOUSMAN ST",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 20
   },
   {
     "id": 210,
@@ -2097,7 +2306,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "3263 EATON RD",
-    "phone": "(920) 433-6700"
+    "phone": "(920) 433-6700",
+    "premium_savings": 0
   },
   {
     "id": 211,
@@ -2107,7 +2317,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "2223 LIME KILN RD STE 1",
-    "phone": "(920) 430-8113"
+    "phone": "(920) 430-8113",
+    "premium_savings": 5
   },
   {
     "id": 212,
@@ -2117,7 +2328,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "3263 EATON RD",
-    "phone": "(920) 433-6700"
+    "phone": "(920) 433-6700",
+    "premium_savings": 10
   },
   {
     "id": 213,
@@ -2127,7 +2339,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "1000 MINERAL POINT AVE",
-    "phone": "(608) 756-6868"
+    "phone": "(608) 756-6868",
+    "premium_savings": 15
   },
   {
     "id": 214,
@@ -2137,7 +2350,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "3524 E MILWAUKEE ST",
-    "phone": "(608) 756-7217"
+    "phone": "(608) 756-7217",
+    "premium_savings": 20
   },
   {
     "id": 215,
@@ -2147,7 +2361,8 @@
     "city": "FORT ATKINSON",
     "state": "WI",
     "address": "611 SHERMAN AVE E, FORT HEALTHCARE CENTER FOR DERMATOLOGY",
-    "phone": "(920) 568-1000"
+    "phone": "(920) 568-1000",
+    "premium_savings": 0
   },
   {
     "id": 216,
@@ -2157,7 +2372,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "3524 E MILWAUKEE ST",
-    "phone": "(608) 756-7100"
+    "phone": "(608) 756-7100",
+    "premium_savings": 5
   },
   {
     "id": 217,
@@ -2167,7 +2383,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "1000 MINERAL POINT AVE",
-    "phone": "(608) 756-6890"
+    "phone": "(608) 756-6890",
+    "premium_savings": 10
   },
   {
     "id": 218,
@@ -2177,7 +2394,8 @@
     "city": "BELOIT",
     "state": "WI",
     "address": "1905 E. HUEBBE PARKWAY, BELOIT HEALTH SYSTEM INC.",
-    "phone": "(608) 364-2200"
+    "phone": "(608) 364-2200",
+    "premium_savings": 15
   },
   {
     "id": 219,
@@ -2187,7 +2405,8 @@
     "city": "BELOIT",
     "state": "WI",
     "address": "1905 E. HUEBBE PARKWAY, BELOIT HEALTH SYSTEM (BELOIT CLINIC)",
-    "phone": "(608) 364-1460"
+    "phone": "(608) 364-1460",
+    "premium_savings": 20
   },
   {
     "id": 220,
@@ -2197,7 +2416,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "3200 E RACINE ST",
-    "phone": "(608) 371-8000"
+    "phone": "(608) 371-8000",
+    "premium_savings": 0
   },
   {
     "id": 221,
@@ -2207,7 +2427,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "557 N WASHINGTON ST",
-    "phone": "(608) 754-6000"
+    "phone": "(608) 754-6000",
+    "premium_savings": 5
   },
   {
     "id": 222,
@@ -2217,7 +2438,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "3524 E MILWAUKEE ST",
-    "phone": "(608) 756-7100"
+    "phone": "(608) 756-7100",
+    "premium_savings": 10
   },
   {
     "id": 223,
@@ -2227,7 +2449,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "800 WEST AVE S",
-    "phone": "(608) 392-9862"
+    "phone": "(608) 392-9862",
+    "premium_savings": 15
   },
   {
     "id": 224,
@@ -2237,7 +2460,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "800 WEST AVE S",
-    "phone": "(608) 392-9555"
+    "phone": "(608) 392-9555",
+    "premium_savings": 20
   },
   {
     "id": 225,
@@ -2247,7 +2471,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 0
   },
   {
     "id": 226,
@@ -2257,7 +2482,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 5
   },
   {
     "id": 227,
@@ -2267,7 +2493,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "800 WEST AVE S",
-    "phone": "(608) 785-0940"
+    "phone": "(608) 785-0940",
+    "premium_savings": 10
   },
   {
     "id": 228,
@@ -2277,7 +2504,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 15
   },
   {
     "id": 229,
@@ -2287,7 +2515,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "700 WEST AVENUE S",
-    "phone": "(608) 785-0940"
+    "phone": "(608) 785-0940",
+    "premium_savings": 20
   },
   {
     "id": 230,
@@ -2297,7 +2526,8 @@
     "city": "ONALASKA",
     "state": "WI",
     "address": "3111 GUNDERSEN DR",
-    "phone": "(608) 775-8100"
+    "phone": "(608) 775-8100",
+    "premium_savings": 0
   },
   {
     "id": 231,
@@ -2307,7 +2537,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 5
   },
   {
     "id": 232,
@@ -2317,7 +2548,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 10
   },
   {
     "id": 233,
@@ -2327,7 +2559,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 15
   },
   {
     "id": 234,
@@ -2337,7 +2570,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "1400 BELLINGER ST",
-    "phone": "(715) 838-5222"
+    "phone": "(715) 838-5222",
+    "premium_savings": 20
   },
   {
     "id": 235,
@@ -2347,7 +2581,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 0
   },
   {
     "id": 236,
@@ -2357,7 +2592,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "700 WEST AVE S",
-    "phone": "(608) 785-0940"
+    "phone": "(608) 785-0940",
+    "premium_savings": 5
   },
   {
     "id": 237,
@@ -2367,7 +2603,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 10
   },
   {
     "id": 238,
@@ -2377,7 +2614,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "700 WEST AVE S",
-    "phone": "(608) 785-0940"
+    "phone": "(608) 785-0940",
+    "premium_savings": 15
   },
   {
     "id": 239,
@@ -2387,7 +2625,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 20
   },
   {
     "id": 240,
@@ -2397,7 +2636,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 0
   },
   {
     "id": 241,
@@ -2407,7 +2647,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "800 WEST AVE S",
-    "phone": "(608) 785-0940"
+    "phone": "(608) 785-0940",
+    "premium_savings": 5
   },
   {
     "id": 242,
@@ -2417,7 +2658,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 10
   },
   {
     "id": 243,
@@ -2427,7 +2669,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "800 WEST AVE S",
-    "phone": "(608) 785-0940"
+    "phone": "(608) 785-0940",
+    "premium_savings": 15
   },
   {
     "id": 244,
@@ -2437,7 +2680,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 20
   },
   {
     "id": 245,
@@ -2447,7 +2691,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "700 WEST AVE S",
-    "phone": "(608) 785-0940"
+    "phone": "(608) 785-0940",
+    "premium_savings": 0
   },
   {
     "id": 246,
@@ -2457,7 +2702,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "800 WEST AVE S",
-    "phone": "(608) 785-0940"
+    "phone": "(608) 785-0940",
+    "premium_savings": 5
   },
   {
     "id": 247,
@@ -2467,7 +2713,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 10
   },
   {
     "id": 248,
@@ -2477,7 +2724,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 15
   },
   {
     "id": 249,
@@ -2487,7 +2735,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "800 WEST AVE S",
-    "phone": "(608) 392-9876"
+    "phone": "(608) 392-9876",
+    "premium_savings": 20
   },
   {
     "id": 250,
@@ -2497,7 +2746,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 0
   },
   {
     "id": 251,
@@ -2507,7 +2757,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 5
   },
   {
     "id": 252,
@@ -2517,7 +2768,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "700 WEST AVE S",
-    "phone": "(608) 392-5859"
+    "phone": "(608) 392-5859",
+    "premium_savings": 10
   },
   {
     "id": 253,
@@ -2527,7 +2779,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "1836 SOUTH AVE",
-    "phone": "(608) 782-7300"
+    "phone": "(608) 782-7300",
+    "premium_savings": 15
   },
   {
     "id": 254,
@@ -2537,7 +2790,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "7401 104TH AVE STE 100",
-    "phone": "(262) 697-1006"
+    "phone": "(262) 697-1006",
+    "premium_savings": 20
   },
   {
     "id": 255,
@@ -2547,7 +2801,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "8220 75TH ST",
-    "phone": "(414) 908-6500"
+    "phone": "(414) 908-6500",
+    "premium_savings": 0
   },
   {
     "id": 256,
@@ -2557,7 +2812,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY, STE 840",
-    "phone": "(414) 649-3530"
+    "phone": "(414) 649-3530",
+    "premium_savings": 5
   },
   {
     "id": 257,
@@ -2567,7 +2823,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "10400 75TH ST",
-    "phone": "(262) 948-6630"
+    "phone": "(262) 948-6630",
+    "premium_savings": 10
   },
   {
     "id": 258,
@@ -2577,7 +2834,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "6308 8TH AVE",
-    "phone": "(262) 653-3650"
+    "phone": "(262) 653-3650",
+    "premium_savings": 15
   },
   {
     "id": 259,
@@ -2587,7 +2845,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "6308 8TH AVE, STE 3060",
-    "phone": "(262) 656-8271"
+    "phone": "(262) 656-8271",
+    "premium_savings": 20
   },
   {
     "id": 260,
@@ -2597,7 +2856,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "8501 75TH ST, SUITE J",
-    "phone": "(262) 898-4400"
+    "phone": "(262) 898-4400",
+    "premium_savings": 0
   },
   {
     "id": 261,
@@ -2607,7 +2867,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "6815 118TH AVE",
-    "phone": "(262) 857-5600"
+    "phone": "(262) 857-5600",
+    "premium_savings": 5
   },
   {
     "id": 262,
@@ -2617,7 +2878,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "1020 35TH ST",
-    "phone": "(262) 652-3500"
+    "phone": "(262) 652-3500",
+    "premium_savings": 10
   },
   {
     "id": 263,
@@ -2627,7 +2889,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "10400 75TH ST",
-    "phone": "(629) 487-0002"
+    "phone": "(629) 487-0002",
+    "premium_savings": 15
   },
   {
     "id": 264,
@@ -2637,7 +2900,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "6308 8TH AVE, STE 202",
-    "phone": "(262) 653-5330"
+    "phone": "(262) 653-5330",
+    "premium_savings": 20
   },
   {
     "id": 265,
@@ -2647,7 +2911,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-2901"
+    "phone": "(414) 805-2901",
+    "premium_savings": 0
   },
   {
     "id": 266,
@@ -2657,7 +2922,8 @@
     "city": "BURLINGTON",
     "state": "WI",
     "address": "709 SPRING VALLEY RD",
-    "phone": "(262) 767-6020"
+    "phone": "(262) 767-6020",
+    "premium_savings": 5
   },
   {
     "id": 267,
@@ -2667,7 +2933,8 @@
     "city": "BURLINGTON",
     "state": "WI",
     "address": "709 SPRING VALLEY RD",
-    "phone": "(262) 767-6020"
+    "phone": "(262) 767-6020",
+    "premium_savings": 10
   },
   {
     "id": 268,
@@ -2677,7 +2944,8 @@
     "city": "RACINE",
     "state": "WI",
     "address": "8400 WASHINGTON AVE",
-    "phone": "(262) 321-3000"
+    "phone": "(262) 321-3000",
+    "premium_savings": 15
   },
   {
     "id": 269,
@@ -2687,7 +2955,8 @@
     "city": "MOUNT PLEASANT",
     "state": "WI",
     "address": "13250 WASHINGTON AVE",
-    "phone": "(888) 720-2012"
+    "phone": "(888) 720-2012",
+    "premium_savings": 20
   },
   {
     "id": 270,
@@ -2697,7 +2966,8 @@
     "city": "PLEASANT PRAIRIE",
     "state": "WI",
     "address": "9697 SAINT CATHERINES DR, SUITE 200",
-    "phone": "(262) 656-3590"
+    "phone": "(262) 656-3590",
+    "premium_savings": 0
   },
   {
     "id": 271,
@@ -2707,7 +2977,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "7401 104TH AVE, SUITE 110",
-    "phone": "(262) 764-5595"
+    "phone": "(262) 764-5595",
+    "premium_savings": 5
   },
   {
     "id": 272,
@@ -2717,7 +2988,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "7401 104TH AVE, SUITE 110",
-    "phone": "(262) 764-5595"
+    "phone": "(262) 764-5595",
+    "premium_savings": 10
   },
   {
     "id": 273,
@@ -2727,7 +2999,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-7400"
+    "phone": "(414) 805-7400",
+    "premium_savings": 15
   },
   {
     "id": 274,
@@ -2737,7 +3010,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "7401 104TH AVE, SUITE 110",
-    "phone": "(262) 764-5595"
+    "phone": "(262) 764-5595",
+    "premium_savings": 20
   },
   {
     "id": 275,
@@ -2747,7 +3021,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "7401 104TH AVE STE 110",
-    "phone": "(262) 764-5595"
+    "phone": "(262) 764-5595",
+    "premium_savings": 0
   },
   {
     "id": 276,
@@ -2757,7 +3032,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY, SUITE 345",
-    "phone": "(414) 649-7900"
+    "phone": "(414) 649-7900",
+    "premium_savings": 5
   },
   {
     "id": 277,
@@ -2767,7 +3043,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "7401 104TH AVE STE 110",
-    "phone": "(262) 764-5595"
+    "phone": "(262) 764-5595",
+    "premium_savings": 10
   },
   {
     "id": 278,
@@ -2777,7 +3054,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "6308 8TH AVENUE, SUITE 108",
-    "phone": "(262) 653-5300"
+    "phone": "(262) 653-5300",
+    "premium_savings": 15
   },
   {
     "id": 279,
@@ -2787,7 +3065,8 @@
     "city": "PLEASANT PRAIRIE",
     "state": "WI",
     "address": "9697 SAINT CATHERINES DR # 400",
-    "phone": "(262) 577-8300"
+    "phone": "(262) 577-8300",
+    "premium_savings": 20
   },
   {
     "id": 280,
@@ -2797,7 +3076,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 S PARK ST",
-    "phone": "(608) 287-2434"
+    "phone": "(608) 287-2434",
+    "premium_savings": 0
   },
   {
     "id": 281,
@@ -2807,7 +3087,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "4602 EASTPARK BLVD",
-    "phone": "(608) 263-1530"
+    "phone": "(608) 263-1530",
+    "premium_savings": 5
   },
   {
     "id": 282,
@@ -2817,7 +3098,8 @@
     "city": "MONROE",
     "state": "WI",
     "address": "2009 5TH ST",
-    "phone": "(608) 324-2000"
+    "phone": "(608) 324-2000",
+    "premium_savings": 10
   },
   {
     "id": 283,
@@ -2827,7 +3109,8 @@
     "city": "MONROE",
     "state": "WI",
     "address": "515 22ND AVE",
-    "phone": "(608) 324-2000"
+    "phone": "(608) 324-2000",
+    "premium_savings": 15
   },
   {
     "id": 284,
@@ -2837,7 +3120,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 20
   },
   {
     "id": 285,
@@ -2847,7 +3131,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "4602 EASTPARK BLVD",
-    "phone": "(608) 263-1530"
+    "phone": "(608) 263-1530",
+    "premium_savings": 0
   },
   {
     "id": 286,
@@ -2857,7 +3142,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "2601 W BELTLINE HWY",
-    "phone": "(608) 417-2100"
+    "phone": "(608) 417-2100",
+    "premium_savings": 5
   },
   {
     "id": 287,
@@ -2867,7 +3153,8 @@
     "city": "MONROE",
     "state": "WI",
     "address": "515 22ND AVE",
-    "phone": "(608) 324-2000"
+    "phone": "(608) 324-2000",
+    "premium_savings": 10
   },
   {
     "id": 288,
@@ -2877,7 +3164,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST, DEAN & ST. MARY'S OUTPATIENT CENTER",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 15
   },
   {
     "id": 289,
@@ -2887,7 +3175,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "2601 W BELTLINE HWY STE 200",
-    "phone": "(608) 287-2434"
+    "phone": "(608) 287-2434",
+    "premium_savings": 20
   },
   {
     "id": 290,
@@ -2897,7 +3186,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "2601 W BELTLINE HWY",
-    "phone": "(608) 287-2434"
+    "phone": "(608) 287-2434",
+    "premium_savings": 0
   },
   {
     "id": 291,
@@ -2907,7 +3197,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "3200 E RACINE ST",
-    "phone": "(608) 371-8000"
+    "phone": "(608) 371-8000",
+    "premium_savings": 5
   },
   {
     "id": 292,
@@ -2917,7 +3208,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1821 S STOUGHTON RD",
-    "phone": "(608) 260-6000"
+    "phone": "(608) 260-6000",
+    "premium_savings": 10
   },
   {
     "id": 293,
@@ -2927,7 +3219,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "752 N HIGH POINT RD",
-    "phone": "(608) 824-4000"
+    "phone": "(608) 824-4000",
+    "premium_savings": 15
   },
   {
     "id": 294,
@@ -2937,7 +3230,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 S PARK ST",
-    "phone": "(608) 287-2450"
+    "phone": "(608) 287-2450",
+    "premium_savings": 20
   },
   {
     "id": 295,
@@ -2947,7 +3241,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 265-7670"
+    "phone": "(608) 265-7670",
+    "premium_savings": 0
   },
   {
     "id": 296,
@@ -2957,7 +3252,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "752 N HIGH POINT RD",
-    "phone": "(608) 824-4000"
+    "phone": "(608) 824-4000",
+    "premium_savings": 5
   },
   {
     "id": 297,
@@ -2967,7 +3263,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1821 S STOUGHTON RD",
-    "phone": "(608) 260-6000"
+    "phone": "(608) 260-6000",
+    "premium_savings": 10
   },
   {
     "id": 298,
@@ -2977,7 +3274,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 S PARK ST, 7TH FLOOR",
-    "phone": "(608) 287-2450"
+    "phone": "(608) 287-2450",
+    "premium_savings": 15
   },
   {
     "id": 299,
@@ -2987,7 +3285,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 S PARK ST, 7TH FLOOR, DEPARTMENT OF DERMATOLOGY,UNIVERSITY OF WISCONSIN",
-    "phone": "(608) 287-2620"
+    "phone": "(608) 287-2620",
+    "premium_savings": 20
   },
   {
     "id": 300,
@@ -2997,7 +3296,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 265-7670"
+    "phone": "(608) 265-7670",
+    "premium_savings": 0
   },
   {
     "id": 301,
@@ -3007,7 +3307,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 S PARK ST",
-    "phone": "(608) 287-2450"
+    "phone": "(608) 287-2450",
+    "premium_savings": 5
   },
   {
     "id": 302,
@@ -3017,7 +3318,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 265-0700"
+    "phone": "(608) 265-0700",
+    "premium_savings": 10
   },
   {
     "id": 303,
@@ -3027,7 +3329,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 263-5010"
+    "phone": "(608) 263-5010",
+    "premium_savings": 15
   },
   {
     "id": 304,
@@ -3037,7 +3340,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "345 W WASHINGTON AVE",
-    "phone": "(608) 417-8300"
+    "phone": "(608) 417-8300",
+    "premium_savings": 20
   },
   {
     "id": 305,
@@ -3047,7 +3351,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 263-7741"
+    "phone": "(608) 263-7741",
+    "premium_savings": 0
   },
   {
     "id": 306,
@@ -3057,7 +3362,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 263-5010"
+    "phone": "(608) 263-5010",
+    "premium_savings": 5
   },
   {
     "id": 307,
@@ -3067,7 +3373,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "345 W WASHINGTON AVE",
-    "phone": "(608) 417-8300"
+    "phone": "(608) 417-8300",
+    "premium_savings": 10
   },
   {
     "id": 308,
@@ -3077,7 +3384,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 263-5010"
+    "phone": "(608) 263-5010",
+    "premium_savings": 15
   },
   {
     "id": 309,
@@ -3087,7 +3395,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "5249 E TERRACE DR",
-    "phone": "(608) 265-7406"
+    "phone": "(608) 265-7406",
+    "premium_savings": 20
   },
   {
     "id": 310,
@@ -3097,7 +3406,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1821 S STOUGHTON RD",
-    "phone": "(608) 260-6000"
+    "phone": "(608) 260-6000",
+    "premium_savings": 0
   },
   {
     "id": 311,
@@ -3107,7 +3417,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1821 S STOUGHTON RD",
-    "phone": "(608) 260-6000"
+    "phone": "(608) 260-6000",
+    "premium_savings": 5
   },
   {
     "id": 312,
@@ -3117,7 +3428,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "750 UNIVERSITY ROW",
-    "phone": "(608) 890-5090"
+    "phone": "(608) 890-5090",
+    "premium_savings": 10
   },
   {
     "id": 313,
@@ -3127,7 +3439,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "750 UNIVERSITY ROW",
-    "phone": "(608) 890-5090"
+    "phone": "(608) 890-5090",
+    "premium_savings": 15
   },
   {
     "id": 314,
@@ -3137,7 +3450,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "20 S PARK ST",
-    "phone": "(608) 287-2680"
+    "phone": "(608) 287-2680",
+    "premium_savings": 20
   },
   {
     "id": 315,
@@ -3147,7 +3461,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "750 UNIVERSITY ROW",
-    "phone": "(608) 890-5010"
+    "phone": "(608) 890-5010",
+    "premium_savings": 0
   },
   {
     "id": 316,
@@ -3157,7 +3472,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 263-8094"
+    "phone": "(608) 263-8094",
+    "premium_savings": 5
   },
   {
     "id": 317,
@@ -3167,7 +3483,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "750 UNIVERSITY ROW",
-    "phone": "(608) 890-5010"
+    "phone": "(608) 890-5010",
+    "premium_savings": 10
   },
   {
     "id": 318,
@@ -3177,7 +3494,8 @@
     "city": "MONROE",
     "state": "WI",
     "address": "515 22ND AVENUE, MONROE CLINIC",
-    "phone": "(608) 324-2222"
+    "phone": "(608) 324-2222",
+    "premium_savings": 15
   },
   {
     "id": 319,
@@ -3187,7 +3505,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "750 UNIVERSITY ROW",
-    "phone": "(608) 890-5000"
+    "phone": "(608) 890-5000",
+    "premium_savings": 20
   },
   {
     "id": 320,
@@ -3197,7 +3516,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST STE A",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 0
   },
   {
     "id": 321,
@@ -3207,7 +3527,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 5
   },
   {
     "id": 322,
@@ -3217,7 +3538,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 10
   },
   {
     "id": 323,
@@ -3227,7 +3549,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "20 S PARK ST, SUITE 207",
-    "phone": "(608) 287-2680"
+    "phone": "(608) 287-2680",
+    "premium_savings": 15
   },
   {
     "id": 324,
@@ -3237,7 +3560,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 263-8094"
+    "phone": "(608) 263-8094",
+    "premium_savings": 20
   },
   {
     "id": 325,
@@ -3247,7 +3571,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "750 UNIVERSITY ROW",
-    "phone": "(608) 890-5000"
+    "phone": "(608) 890-5000",
+    "premium_savings": 0
   },
   {
     "id": 326,
@@ -3257,7 +3582,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "202 S PARK ST",
-    "phone": "(608) 417-5454"
+    "phone": "(608) 417-5454",
+    "premium_savings": 5
   },
   {
     "id": 327,
@@ -3267,7 +3593,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "750 UNIVERSITY ROW",
-    "phone": "(608) 890-5090"
+    "phone": "(608) 890-5090",
+    "premium_savings": 10
   },
   {
     "id": 328,
@@ -3277,7 +3604,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 265-8528"
+    "phone": "(608) 265-8528",
+    "premium_savings": 15
   },
   {
     "id": 329,
@@ -3287,7 +3615,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "3200 E RACINE ST",
-    "phone": "(608) 371-8000"
+    "phone": "(608) 371-8000",
+    "premium_savings": 20
   },
   {
     "id": 330,
@@ -3297,7 +3626,8 @@
     "city": "WISCONSIN RAPIDS",
     "state": "WI",
     "address": "410 DEWEY STREET",
-    "phone": "(715) 421-7442"
+    "phone": "(715) 421-7442",
+    "premium_savings": 0
   },
   {
     "id": 331,
@@ -3307,7 +3637,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1211 FISH HATCHERY RD",
-    "phone": "(608) 252-8000"
+    "phone": "(608) 252-8000",
+    "premium_savings": 5
   },
   {
     "id": 332,
@@ -3317,7 +3648,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 10
   },
   {
     "id": 333,
@@ -3327,7 +3659,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 15
   },
   {
     "id": 334,
@@ -3337,7 +3670,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST STE A",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 20
   },
   {
     "id": 335,
@@ -3347,7 +3681,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "20 S PARK ST STE 202",
-    "phone": "(608) 287-2090"
+    "phone": "(608) 287-2090",
+    "premium_savings": 0
   },
   {
     "id": 336,
@@ -3357,7 +3692,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST STE A",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 5
   },
   {
     "id": 337,
@@ -3367,7 +3703,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "20 S PARK ST",
-    "phone": "(608) 287-2090"
+    "phone": "(608) 287-2090",
+    "premium_savings": 10
   },
   {
     "id": 338,
@@ -3377,7 +3714,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "700 S PARK ST",
-    "phone": "(608) 260-2900"
+    "phone": "(608) 260-2900",
+    "premium_savings": 15
   },
   {
     "id": 339,
@@ -3387,7 +3725,8 @@
     "city": "JANESVILLE",
     "state": "WI",
     "address": "3200 E RACINE ST",
-    "phone": "(608) 371-8000"
+    "phone": "(608) 371-8000",
+    "premium_savings": 20
   },
   {
     "id": 340,
@@ -3397,7 +3736,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "2402 WINNEBAGO ST",
-    "phone": "(608) 242-6840"
+    "phone": "(608) 242-6840",
+    "premium_savings": 0
   },
   {
     "id": 341,
@@ -3407,7 +3747,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "752 N HIGH POINT RD",
-    "phone": "(608) 824-4000"
+    "phone": "(608) 824-4000",
+    "premium_savings": 5
   },
   {
     "id": 342,
@@ -3417,7 +3758,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1211 FISH HATCHERY RD",
-    "phone": "(608) 252-8000"
+    "phone": "(608) 252-8000",
+    "premium_savings": 10
   },
   {
     "id": 343,
@@ -3427,7 +3769,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 15
   },
   {
     "id": 344,
@@ -3437,7 +3780,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1211 FISH HATCHERY RD",
-    "phone": "(608) 252-8000"
+    "phone": "(608) 252-8000",
+    "premium_savings": 20
   },
   {
     "id": 345,
@@ -3447,7 +3791,8 @@
     "city": "ALTOONA",
     "state": "WI",
     "address": "3119 WOODMAN DR",
-    "phone": "(920) 496-4700"
+    "phone": "(920) 496-4700",
+    "premium_savings": 0
   },
   {
     "id": 346,
@@ -3457,7 +3802,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "621 SCIENCE DR",
-    "phone": "(608) 265-3207"
+    "phone": "(608) 265-3207",
+    "premium_savings": 5
   },
   {
     "id": 347,
@@ -3467,7 +3813,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "2501 W BELTLINE HWY STE 601",
-    "phone": "(608) 234-7436"
+    "phone": "(608) 234-7436",
+    "premium_savings": 10
   },
   {
     "id": 348,
@@ -3477,7 +3824,8 @@
     "city": "SAUK CITY",
     "state": "WI",
     "address": "208 PHILLIPS BLVD",
-    "phone": "(608) 644-0109"
+    "phone": "(608) 644-0109",
+    "premium_savings": 15
   },
   {
     "id": 349,
@@ -3487,7 +3835,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 S PARK ST",
-    "phone": "(608) 287-2700"
+    "phone": "(608) 287-2700",
+    "premium_savings": 20
   },
   {
     "id": 350,
@@ -3497,7 +3846,8 @@
     "city": "PRAIRIE DU SAC",
     "state": "WI",
     "address": "260 26TH ST",
-    "phone": "(608) 643-2471"
+    "phone": "(608) 643-2471",
+    "premium_savings": 0
   },
   {
     "id": 351,
@@ -3507,7 +3857,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 S PARK ST, DIVISION OF HAND SURGERY",
-    "phone": "(608) 287-2700"
+    "phone": "(608) 287-2700",
+    "premium_savings": 5
   },
   {
     "id": 352,
@@ -3517,7 +3868,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "2501 W BELTLINE HWY STE 601",
-    "phone": "(608) 234-7436"
+    "phone": "(608) 234-7436",
+    "premium_savings": 10
   },
   {
     "id": 353,
@@ -3527,7 +3879,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "4602 EASTPARK BLVD",
-    "phone": "(608) 263-7540"
+    "phone": "(608) 263-7540",
+    "premium_savings": 15
   },
   {
     "id": 354,
@@ -3537,7 +3890,8 @@
     "city": "LA CROSSE",
     "state": "WI",
     "address": "800 WEST AVE S",
-    "phone": "(608) 785-0940"
+    "phone": "(608) 785-0940",
+    "premium_savings": 20
   },
   {
     "id": 355,
@@ -3547,7 +3901,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1211 FISH HATCHERY RD",
-    "phone": "(608) 252-8000"
+    "phone": "(608) 252-8000",
+    "premium_savings": 0
   },
   {
     "id": 356,
@@ -3557,7 +3912,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1211 FISH HATCHERY RD",
-    "phone": "(608) 252-8000"
+    "phone": "(608) 252-8000",
+    "premium_savings": 5
   },
   {
     "id": 357,
@@ -3567,7 +3923,8 @@
     "city": "PRAIRIE DU SAC",
     "state": "WI",
     "address": "260 26TH ST",
-    "phone": "(608) 643-2471"
+    "phone": "(608) 643-2471",
+    "premium_savings": 10
   },
   {
     "id": 358,
@@ -3577,7 +3934,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1624 S HIGH POINT RD",
-    "phone": "(608) 287-2700"
+    "phone": "(608) 287-2700",
+    "premium_savings": 15
   },
   {
     "id": 359,
@@ -3587,7 +3945,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "4602 EASTPARK BLVD",
-    "phone": "(608) 265-3207"
+    "phone": "(608) 265-3207",
+    "premium_savings": 20
   },
   {
     "id": 360,
@@ -3597,7 +3956,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1211 FISH HATCHERY RD",
-    "phone": "(608) 252-8000"
+    "phone": "(608) 252-8000",
+    "premium_savings": 0
   },
   {
     "id": 361,
@@ -3607,7 +3967,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1821 S STOUGHTON RD",
-    "phone": "(608) 260-6000"
+    "phone": "(608) 260-6000",
+    "premium_savings": 5
   },
   {
     "id": 362,
@@ -3617,7 +3978,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1821 S STOUGHTON RD",
-    "phone": "(608) 260-6000"
+    "phone": "(608) 260-6000",
+    "premium_savings": 10
   },
   {
     "id": 363,
@@ -3627,7 +3989,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 S PARK ST",
-    "phone": "(608) 287-2800"
+    "phone": "(608) 287-2800",
+    "premium_savings": 15
   },
   {
     "id": 364,
@@ -3637,7 +4000,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 S PARK ST",
-    "phone": "(608) 287-2800"
+    "phone": "(608) 287-2800",
+    "premium_savings": 20
   },
   {
     "id": 365,
@@ -3647,7 +4011,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1 SOUTH PARK ST",
-    "phone": "(608) 287-2800"
+    "phone": "(608) 287-2800",
+    "premium_savings": 0
   },
   {
     "id": 366,
@@ -3657,7 +4022,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 263-7577"
+    "phone": "(608) 263-7577",
+    "premium_savings": 5
   },
   {
     "id": 367,
@@ -3667,7 +4033,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "1821 S STOUGHTON RD",
-    "phone": "(608) 260-6000"
+    "phone": "(608) 260-6000",
+    "premium_savings": 10
   },
   {
     "id": 368,
@@ -3677,7 +4044,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "2356 S 102ND ST",
-    "phone": "(262) 689-8710"
+    "phone": "(262) 689-8710",
+    "premium_savings": 15
   },
   {
     "id": 369,
@@ -3687,7 +4055,8 @@
     "city": "WEST BEND",
     "state": "WI",
     "address": "3212 PLEASANT VALLEY RD",
-    "phone": "(262) 334-6165"
+    "phone": "(262) 334-6165",
+    "premium_savings": 20
   },
   {
     "id": 370,
@@ -3697,7 +4066,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "1111 DELAFIELD ST, SUITE 322",
-    "phone": "(414) 454-0600"
+    "phone": "(414) 454-0600",
+    "premium_savings": 0
   },
   {
     "id": 371,
@@ -3707,7 +4077,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 303-5000"
+    "phone": "(262) 303-5000",
+    "premium_savings": 5
   },
   {
     "id": 372,
@@ -3717,7 +4088,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "2424 S 90TH ST",
-    "phone": "(414) 908-6500"
+    "phone": "(414) 908-6500",
+    "premium_savings": 10
   },
   {
     "id": 373,
@@ -3727,7 +4099,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "W180N8045 TOWN HALL RD",
-    "phone": "(262) 250-0950"
+    "phone": "(262) 250-0950",
+    "premium_savings": 15
   },
   {
     "id": 374,
@@ -3737,7 +4110,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1060",
-    "phone": "(414) 908-6500"
+    "phone": "(414) 908-6500",
+    "premium_savings": 20
   },
   {
     "id": 375,
@@ -3747,7 +4121,8 @@
     "city": "CUDAHY",
     "state": "WI",
     "address": "5900 S. LAKE DRIVE, LAKESHORE MEDICAL CLINIC",
-    "phone": "(414) 489-4190"
+    "phone": "(414) 489-4190",
+    "premium_savings": 0
   },
   {
     "id": 376,
@@ -3757,7 +4132,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "960 N 12TH ST, SUITE 400",
-    "phone": "(414) 219-7653"
+    "phone": "(414) 219-7653",
+    "premium_savings": 5
   },
   {
     "id": 377,
@@ -3767,7 +4143,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "W180N7950 TOWN HALL RD",
-    "phone": "(262) 255-2500"
+    "phone": "(262) 255-2500",
+    "premium_savings": 10
   },
   {
     "id": 378,
@@ -3777,7 +4154,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2025 W OKLAHOMA AVE STE 105",
-    "phone": "(414) 389-2797"
+    "phone": "(414) 389-2797",
+    "premium_savings": 15
   },
   {
     "id": 379,
@@ -3787,7 +4165,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DIVISION OF CARDIOLOGY",
-    "phone": "(414) 955-6777"
+    "phone": "(414) 955-6777",
+    "premium_savings": 20
   },
   {
     "id": 380,
@@ -3797,7 +4176,8 @@
     "city": "GERMANTOWN",
     "state": "WI",
     "address": "W180N11070 RIVER LIN",
-    "phone": "(262) 532-8441"
+    "phone": "(262) 532-8441",
+    "premium_savings": 0
   },
   {
     "id": 381,
@@ -3807,7 +4187,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-6000"
+    "phone": "(414) 805-6000",
+    "premium_savings": 5
   },
   {
     "id": 382,
@@ -3817,7 +4198,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "N84W16889 MENOMONEE AVE",
-    "phone": "(262) 251-7500"
+    "phone": "(262) 251-7500",
+    "premium_savings": 10
   },
   {
     "id": 383,
@@ -3827,7 +4209,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY, 840",
-    "phone": "(414) 649-3530"
+    "phone": "(414) 649-3530",
+    "premium_savings": 15
   },
   {
     "id": 384,
@@ -3837,7 +4220,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-6000"
+    "phone": "(414) 805-6000",
+    "premium_savings": 20
   },
   {
     "id": 385,
@@ -3847,7 +4231,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W. KINNICKINNIC RIVER PKWY., SUITE 925",
-    "phone": "(414) 385-2499"
+    "phone": "(414) 385-2499",
+    "premium_savings": 0
   },
   {
     "id": 386,
@@ -3857,7 +4242,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "16650 W BLUEMOUND RD, SUITE 200",
-    "phone": "(262) 827-9200"
+    "phone": "(262) 827-9200",
+    "premium_savings": 5
   },
   {
     "id": 387,
@@ -3867,7 +4253,8 @@
     "city": "FRANKLIN",
     "state": "WI",
     "address": "7400 W RAWSON AVE STE 143",
-    "phone": "(414) 425-7380"
+    "phone": "(414) 425-7380",
+    "premium_savings": 10
   },
   {
     "id": 388,
@@ -3877,7 +4264,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2900 W OKLAHOMA AVE",
-    "phone": "(414) 649-6000"
+    "phone": "(414) 649-6000",
+    "premium_savings": 15
   },
   {
     "id": 389,
@@ -3887,7 +4275,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DIVISION OF CARDIOLOGY",
-    "phone": "(414) 805-6633"
+    "phone": "(414) 805-6633",
+    "premium_savings": 20
   },
   {
     "id": 390,
@@ -3897,7 +4286,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "16650 W BLUEMOUND RD, SUITE 200",
-    "phone": "(262) 827-9200"
+    "phone": "(262) 827-9200",
+    "premium_savings": 0
   },
   {
     "id": 391,
@@ -3907,7 +4297,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "2424 S 90TH ST",
-    "phone": "(414) 328-8150"
+    "phone": "(414) 328-8150",
+    "premium_savings": 5
   },
   {
     "id": 392,
@@ -3917,7 +4308,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3003 W GOOD HOPE RD",
-    "phone": "(414) 352-3100"
+    "phone": "(414) 352-3100",
+    "premium_savings": 10
   },
   {
     "id": 393,
@@ -3927,7 +4319,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY, #840",
-    "phone": "(414) 649-3530"
+    "phone": "(414) 649-3530",
+    "premium_savings": 15
   },
   {
     "id": 394,
@@ -3937,7 +4330,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "960 N 12TH ST",
-    "phone": "(414) 219-7434"
+    "phone": "(414) 219-7434",
+    "premium_savings": 20
   },
   {
     "id": 395,
@@ -3947,7 +4341,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "601 N 99 ST, STE 201",
-    "phone": "(414) 266-9700"
+    "phone": "(414) 266-9700",
+    "premium_savings": 0
   },
   {
     "id": 396,
@@ -3957,7 +4352,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "725 AMERICAN AVE",
-    "phone": "(262) 928-8800"
+    "phone": "(262) 928-8800",
+    "premium_savings": 5
   },
   {
     "id": 397,
@@ -3967,7 +4363,8 @@
     "city": "GRAFTON",
     "state": "WI",
     "address": "975 PORT WASHINGTON RD",
-    "phone": "(262) 329-1000"
+    "phone": "(262) 329-1000",
+    "premium_savings": 10
   },
   {
     "id": 398,
@@ -3977,7 +4374,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DEPARTMENT OF CARDIOVASCULAR MEDICINE",
-    "phone": "(414) 805-6633"
+    "phone": "(414) 805-6633",
+    "premium_savings": 15
   },
   {
     "id": 399,
@@ -3987,7 +4385,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "721 AMERICAN AVE, SUITE 403",
-    "phone": "(262) 549-1516"
+    "phone": "(262) 549-1516",
+    "premium_savings": 20
   },
   {
     "id": 400,
@@ -3997,7 +4396,8 @@
     "city": "GERMANTOWN",
     "state": "WI",
     "address": "W180N11070 RIVER LN",
-    "phone": "(262) 535-8400"
+    "phone": "(262) 535-8400",
+    "premium_savings": 0
   },
   {
     "id": 401,
@@ -4007,7 +4407,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, CARDIOLOGY",
-    "phone": "(414) 955-6777"
+    "phone": "(414) 955-6777",
+    "premium_savings": 5
   },
   {
     "id": 402,
@@ -4017,7 +4418,8 @@
     "city": "OCEANSIDE",
     "state": "CA",
     "address": "2424 VISTA WAY STE 300-301",
-    "phone": "(760) 630-1606"
+    "phone": "(760) 630-1606",
+    "premium_savings": 10
   },
   {
     "id": 403,
@@ -4027,7 +4429,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DIVISION OF CARDIOLOGY",
-    "phone": "(414) 805-6633"
+    "phone": "(414) 805-6633",
+    "premium_savings": 15
   },
   {
     "id": 404,
@@ -4037,7 +4440,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2350 N LAKE DR STE 400",
-    "phone": "(414) 271-1633"
+    "phone": "(414) 271-1633",
+    "premium_savings": 20
   },
   {
     "id": 405,
@@ -4047,7 +4451,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-6000"
+    "phone": "(414) 805-6000",
+    "premium_savings": 0
   },
   {
     "id": 406,
@@ -4057,7 +4462,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-6000"
+    "phone": "(414) 805-6000",
+    "premium_savings": 5
   },
   {
     "id": 407,
@@ -4067,7 +4473,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DIVISION OF CARDIOLOGY",
-    "phone": "(414) 805-6633"
+    "phone": "(414) 805-6633",
+    "premium_savings": 10
   },
   {
     "id": 408,
@@ -4077,7 +4484,8 @@
     "city": "MEQUON",
     "state": "WI",
     "address": "11725 N PORT WASHINGTON RD STE 250",
-    "phone": "(414) 207-4333"
+    "phone": "(414) 207-4333",
+    "premium_savings": 15
   },
   {
     "id": 409,
@@ -4087,7 +4495,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, CARDIOLOGY",
-    "phone": "(414) 805-3666"
+    "phone": "(414) 805-3666",
+    "premium_savings": 20
   },
   {
     "id": 410,
@@ -4097,7 +4506,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "5434 W CAPITOL DR",
-    "phone": "(414) 442-5400"
+    "phone": "(414) 442-5400",
+    "premium_savings": 0
   },
   {
     "id": 411,
@@ -4107,7 +4517,8 @@
     "city": "GERMANTOWN",
     "state": "WI",
     "address": "N112W15415 MEQUON RD",
-    "phone": "(262) 255-2112"
+    "phone": "(262) 255-2112",
+    "premium_savings": 5
   },
   {
     "id": 412,
@@ -4117,7 +4528,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2350 N LAKE DR STE 300",
-    "phone": "(414) 298-7100"
+    "phone": "(414) 298-7100",
+    "premium_savings": 10
   },
   {
     "id": 413,
@@ -4127,7 +4539,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "13800 W NORTH AVE, STE 100",
-    "phone": "(262) 754-4488"
+    "phone": "(262) 754-4488",
+    "premium_savings": 15
   },
   {
     "id": 414,
@@ -4137,7 +4550,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "N84W16889 MENOMONEE AVE",
-    "phone": "(262) 251-7500"
+    "phone": "(262) 251-7500",
+    "premium_savings": 20
   },
   {
     "id": 415,
@@ -4147,7 +4561,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "13800 W NORTH AVE STE 100",
-    "phone": "(262) 754-4488"
+    "phone": "(262) 754-4488",
+    "premium_savings": 0
   },
   {
     "id": 416,
@@ -4157,7 +4572,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "13800 W NORTH AVE, STE 100",
-    "phone": "(262) 754-4488"
+    "phone": "(262) 754-4488",
+    "premium_savings": 5
   },
   {
     "id": 417,
@@ -4167,7 +4583,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-5320"
+    "phone": "(414) 805-5320",
+    "premium_savings": 10
   },
   {
     "id": 418,
@@ -4177,7 +4594,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 15
   },
   {
     "id": 419,
@@ -4187,7 +4605,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "10000 W BLUEMOUND RD",
-    "phone": "(414) 454-8000"
+    "phone": "(414) 454-8000",
+    "premium_savings": 20
   },
   {
     "id": 420,
@@ -4197,7 +4616,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "13800 W NORTH AVE",
-    "phone": "(262) 754-4488"
+    "phone": "(262) 754-4488",
+    "premium_savings": 0
   },
   {
     "id": 421,
@@ -4207,7 +4627,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "13800 W NORTH AVE, SUITE 100",
-    "phone": "(262) 754-4488"
+    "phone": "(262) 754-4488",
+    "premium_savings": 5
   },
   {
     "id": 422,
@@ -4217,7 +4638,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2350 N LAKE DR STE 300",
-    "phone": "(414) 298-7100"
+    "phone": "(414) 298-7100",
+    "premium_savings": 10
   },
   {
     "id": 423,
@@ -4227,7 +4649,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "13800 W NORTH AVE, STE 100",
-    "phone": "(262) 754-4488"
+    "phone": "(262) 754-4488",
+    "premium_savings": 15
   },
   {
     "id": 424,
@@ -4237,7 +4660,8 @@
     "city": "GERMANTOWN",
     "state": "WI",
     "address": "N112W17975 MEQUON RD",
-    "phone": "(262) 532-7600"
+    "phone": "(262) 532-7600",
+    "premium_savings": 20
   },
   {
     "id": 425,
@@ -4247,7 +4671,8 @@
     "city": "GRAFTON",
     "state": "WI",
     "address": "215 WASHINGTON ST",
-    "phone": "(262) 375-3700"
+    "phone": "(262) 375-3700",
+    "premium_savings": 0
   },
   {
     "id": 426,
@@ -4257,7 +4682,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "N16W24131 RIVERWOOD DR",
-    "phone": "(262) 696-0808"
+    "phone": "(262) 696-0808",
+    "premium_savings": 5
   },
   {
     "id": 427,
@@ -4267,7 +4693,8 @@
     "city": "MEQUON",
     "state": "WI",
     "address": "12203 CORPORATE PKWY",
-    "phone": "(262) 387-8200"
+    "phone": "(262) 387-8200",
+    "premium_savings": 10
   },
   {
     "id": 428,
@@ -4277,7 +4704,8 @@
     "city": "GREENFIELD",
     "state": "WI",
     "address": "6790 W LAYTON AVE",
-    "phone": "(414) 325-8500"
+    "phone": "(414) 325-8500",
+    "premium_savings": 15
   },
   {
     "id": 429,
@@ -4287,7 +4715,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "10000 W BLUEMOUND RD",
-    "phone": "(414) 454-8000"
+    "phone": "(414) 454-8000",
+    "premium_savings": 20
   },
   {
     "id": 430,
@@ -4297,7 +4726,8 @@
     "city": "GREENFIELD",
     "state": "WI",
     "address": "6790 W LAYTON AVE",
-    "phone": "(414) 325-8500"
+    "phone": "(414) 325-8500",
+    "premium_savings": 0
   },
   {
     "id": 431,
@@ -4307,7 +4737,8 @@
     "city": "FRANKLIN",
     "state": "WI",
     "address": "10500 W LOOMIS RD, SUITE 110",
-    "phone": "(262) 898-4400"
+    "phone": "(262) 898-4400",
+    "premium_savings": 5
   },
   {
     "id": 432,
@@ -4317,7 +4748,8 @@
     "city": "GREENFIELD",
     "state": "WI",
     "address": "6901 W EDGERTON AVE",
-    "phone": "(414) 421-8400"
+    "phone": "(414) 421-8400",
+    "premium_savings": 10
   },
   {
     "id": 433,
@@ -4327,7 +4759,8 @@
     "city": "SUSSEX",
     "state": "WI",
     "address": "N57W24950 N CORPORATE CIR",
-    "phone": "(262) 820-3093"
+    "phone": "(262) 820-3093",
+    "premium_savings": 15
   },
   {
     "id": 434,
@@ -4337,7 +4770,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "N16W24131 RIVERWOOD DR, PEWAUKEE CLINIC",
-    "phone": "(262) 696-0808"
+    "phone": "(262) 696-0808",
+    "premium_savings": 20
   },
   {
     "id": 435,
@@ -4347,7 +4781,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "10000 W BLUEMOUND RD",
-    "phone": "(414) 454-4321"
+    "phone": "(414) 454-4321",
+    "premium_savings": 0
   },
   {
     "id": 436,
@@ -4357,7 +4792,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3003 W GOOD HOPE RD",
-    "phone": "(414) 352-3100"
+    "phone": "(414) 352-3100",
+    "premium_savings": 5
   },
   {
     "id": 437,
@@ -4367,7 +4803,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "2323 S 102ND ST",
-    "phone": "(414) 541-9900"
+    "phone": "(414) 541-9900",
+    "premium_savings": 10
   },
   {
     "id": 438,
@@ -4377,7 +4814,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DIVISION OF ENDOCRINOLOGY",
-    "phone": "(414) 456-6722"
+    "phone": "(414) 456-6722",
+    "premium_savings": 15
   },
   {
     "id": 439,
@@ -4387,7 +4825,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "W129N7055 NORTHFIELD DR, ENDOCRINOLOGY CLINIC",
-    "phone": "(262) 253-7155"
+    "phone": "(262) 253-7155",
+    "premium_savings": 20
   },
   {
     "id": 440,
@@ -4397,7 +4836,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "788 N JEFFERSON ST STE 300",
-    "phone": "(414) 272-8950"
+    "phone": "(414) 272-8950",
+    "premium_savings": 0
   },
   {
     "id": 441,
@@ -4407,7 +4847,8 @@
     "city": "HARTLAND",
     "state": "WI",
     "address": "600 WALNUT RIDGE DR",
-    "phone": "(262) 369-7040"
+    "phone": "(262) 369-7040",
+    "premium_savings": 5
   },
   {
     "id": 442,
@@ -4417,7 +4858,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DIVISION OF ENDOCRINOLOGY",
-    "phone": "(414) 955-6724"
+    "phone": "(414) 955-6724",
+    "premium_savings": 10
   },
   {
     "id": 443,
@@ -4427,7 +4869,8 @@
     "city": "PORT WASHINGTON",
     "state": "WI",
     "address": "1475 W GRAND AVE",
-    "phone": "(262) 268-5100"
+    "phone": "(262) 268-5100",
+    "premium_savings": 15
   },
   {
     "id": 444,
@@ -4437,7 +4880,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "788 N JEFFERSON ST, SUITE 201",
-    "phone": "(414) 226-4010"
+    "phone": "(414) 226-4010",
+    "premium_savings": 20
   },
   {
     "id": 445,
@@ -4447,7 +4891,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "201 N MAYFAIR ROAD",
-    "phone": "(414) 771-8228"
+    "phone": "(414) 771-8228",
+    "premium_savings": 0
   },
   {
     "id": 446,
@@ -4457,7 +4902,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "201 N MAYFAIR RD, 2ND F",
-    "phone": "(414) 771-8228"
+    "phone": "(414) 771-8228",
+    "premium_savings": 5
   },
   {
     "id": 447,
@@ -4467,7 +4913,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "W129N7055 NORTHFIELD DR, DIVISION OF ENDOCRINOLOGY",
-    "phone": "(262) 253-7155"
+    "phone": "(262) 253-7155",
+    "premium_savings": 10
   },
   {
     "id": 448,
@@ -4477,7 +4924,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "788 N JEFFERSON ST, SUITE 201",
-    "phone": "(414) 226-4010"
+    "phone": "(414) 226-4010",
+    "premium_savings": 15
   },
   {
     "id": 449,
@@ -4487,7 +4935,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY",
-    "phone": "(414) 649-6780"
+    "phone": "(414) 649-6780",
+    "premium_savings": 20
   },
   {
     "id": 450,
@@ -4497,7 +4946,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVENUE, DIVISION OF ENDOCRINOLOGY",
-    "phone": "(414) 955-6723"
+    "phone": "(414) 955-6723",
+    "premium_savings": 0
   },
   {
     "id": 451,
@@ -4507,7 +4957,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "W129N7055 NORTHFIELD DR",
-    "phone": "(262) 253-7155"
+    "phone": "(262) 253-7155",
+    "premium_savings": 5
   },
   {
     "id": 452,
@@ -4517,7 +4968,8 @@
     "city": "EAU CLAIRE",
     "state": "WI",
     "address": "3802 OAKWOOD MALL DR",
-    "phone": "(715) 839-9280"
+    "phone": "(715) 839-9280",
+    "premium_savings": 10
   },
   {
     "id": 453,
@@ -4527,7 +4979,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "N84W16889 MENOMONEE AVE",
-    "phone": "(262) 251-7500"
+    "phone": "(262) 251-7500",
+    "premium_savings": 15
   },
   {
     "id": 454,
@@ -4537,7 +4990,8 @@
     "city": "CUDAHY",
     "state": "WI",
     "address": "5900 S LAKE DR",
-    "phone": "(414) 489-4190"
+    "phone": "(414) 489-4190",
+    "premium_savings": 20
   },
   {
     "id": 455,
@@ -4547,7 +5001,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "1111 DELAFIELD ST, SUITE 212",
-    "phone": "(262) 544-8622"
+    "phone": "(262) 544-8622",
+    "premium_savings": 0
   },
   {
     "id": 456,
@@ -4557,7 +5012,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6601"
+    "phone": "(414) 908-6601",
+    "premium_savings": 5
   },
   {
     "id": 457,
@@ -4567,7 +5023,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "N84W16889 MENOMONEE AVE",
-    "phone": "(262) 251-7500"
+    "phone": "(262) 251-7500",
+    "premium_savings": 10
   },
   {
     "id": 458,
@@ -4577,7 +5034,8 @@
     "city": "WEST BEND",
     "state": "WI",
     "address": "1700 W PARADISE DR",
-    "phone": "(262) 334-3451"
+    "phone": "(262) 334-3451",
+    "premium_savings": 15
   },
   {
     "id": 459,
@@ -4587,7 +5045,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KK RIVER PKWY STE 1080",
-    "phone": "(414) 908-6500"
+    "phone": "(414) 908-6500",
+    "premium_savings": 20
   },
   {
     "id": 460,
@@ -4597,7 +5056,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-3310"
+    "phone": "(414) 805-3310",
+    "premium_savings": 0
   },
   {
     "id": 461,
@@ -4607,7 +5067,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3003 W GOOD HOPE RD",
-    "phone": "(414) 352-3100"
+    "phone": "(414) 352-3100",
+    "premium_savings": 5
   },
   {
     "id": 462,
@@ -4617,7 +5078,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 10
   },
   {
     "id": 463,
@@ -4627,7 +5089,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KK RIVER PKWY, SUITE 1030",
-    "phone": "(414) 908-6500"
+    "phone": "(414) 908-6500",
+    "premium_savings": 15
   },
   {
     "id": 464,
@@ -4637,7 +5100,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "W129N7055 NORTHFIELD DR, GASTROENTEROLOGY",
-    "phone": "(262) 253-5400"
+    "phone": "(262) 253-5400",
+    "premium_savings": 20
   },
   {
     "id": 465,
@@ -4647,7 +5111,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6615"
+    "phone": "(414) 908-6615",
+    "premium_savings": 0
   },
   {
     "id": 466,
@@ -4657,7 +5122,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KK RIVER PKWY STE 1080",
-    "phone": "(414) 908-6500"
+    "phone": "(414) 908-6500",
+    "premium_savings": 5
   },
   {
     "id": 467,
@@ -4667,7 +5133,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6615"
+    "phone": "(414) 908-6615",
+    "premium_savings": 10
   },
   {
     "id": 468,
@@ -4677,7 +5144,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6500"
+    "phone": "(414) 908-6500",
+    "premium_savings": 15
   },
   {
     "id": 469,
@@ -4687,7 +5155,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2350 N LAKE DR STE 500",
-    "phone": "(414) 226-4020"
+    "phone": "(414) 226-4020",
+    "premium_savings": 20
   },
   {
     "id": 470,
@@ -4697,7 +5166,8 @@
     "city": "MEQUON",
     "state": "WI",
     "address": "13133 N PORT WASHINGTON RD STE G16",
-    "phone": "(847) 909-2695"
+    "phone": "(847) 909-2695",
+    "premium_savings": 0
   },
   {
     "id": 471,
@@ -4707,7 +5177,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "1033 N MAYFAIR RD, SUITE 101",
-    "phone": "(414) 454-0500"
+    "phone": "(414) 454-0500",
+    "premium_savings": 5
   },
   {
     "id": 472,
@@ -4717,7 +5188,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "1111 DELAFIELD ST, SUITE 212",
-    "phone": "(262) 544-8622"
+    "phone": "(262) 544-8622",
+    "premium_savings": 10
   },
   {
     "id": 473,
@@ -4727,7 +5199,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 955-6830"
+    "phone": "(414) 955-6830",
+    "premium_savings": 15
   },
   {
     "id": 474,
@@ -4737,7 +5210,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6615"
+    "phone": "(414) 908-6615",
+    "premium_savings": 20
   },
   {
     "id": 475,
@@ -4747,7 +5221,8 @@
     "city": "MEQUON",
     "state": "WI",
     "address": "13133 N. PORT WASHINGTON ROAD, SUITE G-16",
-    "phone": "(262) 243-2500"
+    "phone": "(262) 243-2500",
+    "premium_savings": 0
   },
   {
     "id": 476,
@@ -4757,7 +5232,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6601"
+    "phone": "(414) 908-6601",
+    "premium_savings": 5
   },
   {
     "id": 477,
@@ -4767,7 +5243,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2311 N PROSPECT AVE",
-    "phone": "(414) 319-3000"
+    "phone": "(414) 319-3000",
+    "premium_savings": 10
   },
   {
     "id": 478,
@@ -4777,7 +5254,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "1033 N MAYFAIR RD, SUITE 101",
-    "phone": "(414) 454-0600"
+    "phone": "(414) 454-0600",
+    "premium_savings": 15
   },
   {
     "id": 479,
@@ -4787,7 +5265,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DIVISION OF GASTROENTEROLOGY AND HEPATOLOGY",
-    "phone": "(414) 805-0516"
+    "phone": "(414) 805-0516",
+    "premium_savings": 20
   },
   {
     "id": 480,
@@ -4797,7 +5276,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6601"
+    "phone": "(414) 908-6601",
+    "premium_savings": 0
   },
   {
     "id": 481,
@@ -4807,7 +5287,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6601"
+    "phone": "(414) 908-6601",
+    "premium_savings": 5
   },
   {
     "id": 482,
@@ -4817,7 +5298,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "2414 KOHLER MEMORIAL DR",
-    "phone": "(920) 457-4461"
+    "phone": "(920) 457-4461",
+    "premium_savings": 10
   },
   {
     "id": 483,
@@ -4827,7 +5309,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-3310"
+    "phone": "(414) 805-3310",
+    "premium_savings": 15
   },
   {
     "id": 484,
@@ -4837,7 +5320,8 @@
     "city": "CUDAHY",
     "state": "WI",
     "address": "3501 E RAMSEY AVE",
-    "phone": "(262) 243-2500"
+    "phone": "(262) 243-2500",
+    "premium_savings": 20
   },
   {
     "id": 485,
@@ -4847,7 +5331,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY, SUITE 930",
-    "phone": "(262) 857-5750"
+    "phone": "(262) 857-5750",
+    "premium_savings": 0
   },
   {
     "id": 486,
@@ -4857,7 +5342,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, CLCC - FIFTH FLOOR",
-    "phone": "(414) 805-0509"
+    "phone": "(414) 805-0509",
+    "premium_savings": 5
   },
   {
     "id": 487,
@@ -4867,7 +5353,8 @@
     "city": "GRAFTON",
     "state": "WI",
     "address": "975 PORT WASHINGTON RD",
-    "phone": "(262) 329-1000"
+    "phone": "(262) 329-1000",
+    "premium_savings": 10
   },
   {
     "id": 488,
@@ -4877,7 +5364,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2900 W OKLAHOMA AVE",
-    "phone": "(414) 649-6380"
+    "phone": "(414) 649-6380",
+    "premium_savings": 15
   },
   {
     "id": 489,
@@ -4887,7 +5375,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2900 W OKLAHOMA AVE",
-    "phone": "(414) 649-6380"
+    "phone": "(414) 649-6380",
+    "premium_savings": 20
   },
   {
     "id": 490,
@@ -4897,7 +5386,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "8901 W LINCOLN AVE",
-    "phone": "(414) 329-5950"
+    "phone": "(414) 329-5950",
+    "premium_savings": 0
   },
   {
     "id": 491,
@@ -4907,7 +5397,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-0505"
+    "phone": "(414) 805-0505",
+    "premium_savings": 5
   },
   {
     "id": 492,
@@ -4917,7 +5408,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "1055 N MAYFAIR RD",
-    "phone": "(262) 857-5750"
+    "phone": "(262) 857-5750",
+    "premium_savings": 10
   },
   {
     "id": 493,
@@ -4927,7 +5419,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "N16W24131 RIVERWOOD DR",
-    "phone": "(262) 696-5690"
+    "phone": "(262) 696-5690",
+    "premium_savings": 15
   },
   {
     "id": 494,
@@ -4937,7 +5430,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-4600"
+    "phone": "(414) 805-4600",
+    "premium_savings": 20
   },
   {
     "id": 495,
@@ -4947,7 +5441,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "1218 W KILBOURN AVE, SUITE 200",
-    "phone": "(414) 219-7370"
+    "phone": "(414) 219-7370",
+    "premium_savings": 0
   },
   {
     "id": 496,
@@ -4957,7 +5452,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY, SUITE 930",
-    "phone": "(414) 384-5111"
+    "phone": "(414) 384-5111",
+    "premium_savings": 5
   },
   {
     "id": 497,
@@ -4967,7 +5463,8 @@
     "city": "WEST BEND",
     "state": "WI",
     "address": "3200 PLEASANT VALLEY RD, ALYCE & ELMORE KRAEMER CANCER CARE CTR",
-    "phone": "(262) 836-7200"
+    "phone": "(262) 836-7200",
+    "premium_savings": 10
   },
   {
     "id": 498,
@@ -4977,7 +5474,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3003 W GOOD HOPE RD",
-    "phone": "(414) 352-3100"
+    "phone": "(414) 352-3100",
+    "premium_savings": 15
   },
   {
     "id": 499,
@@ -4987,7 +5485,8 @@
     "city": "GERMANTOWN",
     "state": "WI",
     "address": "W180N11070 RIVER LN",
-    "phone": "(262) 535-8400"
+    "phone": "(262) 535-8400",
+    "premium_savings": 20
   },
   {
     "id": 500,
@@ -4997,7 +5496,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, NEOPLASTIC DISEASES",
-    "phone": "(414) 805-6800"
+    "phone": "(414) 805-6800",
+    "premium_savings": 0
   },
   {
     "id": 501,
@@ -5007,7 +5507,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, NEOPLASTIC DISEASES",
-    "phone": "(414) 805-4600"
+    "phone": "(414) 805-4600",
+    "premium_savings": 5
   },
   {
     "id": 502,
@@ -5017,7 +5518,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "8901 W LINCOLN AVE",
-    "phone": "(262) 857-5750"
+    "phone": "(262) 857-5750",
+    "premium_savings": 10
   },
   {
     "id": 503,
@@ -5027,7 +5529,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DIVISION OF NEOPLASTIC DISEASES",
-    "phone": "(414) 805-4600"
+    "phone": "(414) 805-4600",
+    "premium_savings": 15
   },
   {
     "id": 504,
@@ -5037,7 +5540,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2350 N LAKE DR, SUITE 100",
-    "phone": "(414) 298-7250"
+    "phone": "(414) 298-7250",
+    "premium_savings": 20
   },
   {
     "id": 505,
@@ -5047,7 +5551,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3003 W GOOD HOPE RD",
-    "phone": "(414) 352-3100"
+    "phone": "(414) 352-3100",
+    "premium_savings": 0
   },
   {
     "id": 506,
@@ -5057,7 +5562,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "W180N7950 TOWN HALL RD",
-    "phone": "(262) 255-2500"
+    "phone": "(262) 255-2500",
+    "premium_savings": 5
   },
   {
     "id": 507,
@@ -5067,7 +5573,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DEPARTMENT OF NEUROLOGY",
-    "phone": "(414) 805-5200"
+    "phone": "(414) 805-5200",
+    "premium_savings": 10
   },
   {
     "id": 508,
@@ -5077,7 +5584,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DEPARTMENT OF NEUROLOGY, MCW",
-    "phone": "(414) 805-5200"
+    "phone": "(414) 805-5200",
+    "premium_savings": 15
   },
   {
     "id": 509,
@@ -5087,7 +5595,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "N84W16889 MENOMONEE AVE",
-    "phone": "(262) 251-7500"
+    "phone": "(262) 251-7500",
+    "premium_savings": 20
   },
   {
     "id": 510,
@@ -5097,7 +5606,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 550",
-    "phone": "(414) 385-8780"
+    "phone": "(414) 385-8780",
+    "premium_savings": 0
   },
   {
     "id": 511,
@@ -5107,7 +5617,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-5200"
+    "phone": "(414) 805-5200",
+    "premium_savings": 5
   },
   {
     "id": 512,
@@ -5117,7 +5628,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3003 W GOOD HOPE RD",
-    "phone": "(414) 352-3100"
+    "phone": "(414) 352-3100",
+    "premium_savings": 10
   },
   {
     "id": 513,
@@ -5127,7 +5639,8 @@
     "city": "OAK CREEK",
     "state": "WI",
     "address": "2603 W RAWSON AVE, SUITE 128",
-    "phone": "(414) 431-6760"
+    "phone": "(414) 431-6760",
+    "premium_savings": 15
   },
   {
     "id": 514,
@@ -5137,7 +5650,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "13950 W CAPITOL DRIVE",
-    "phone": "(414) 302-5400"
+    "phone": "(414) 302-5400",
+    "premium_savings": 20
   },
   {
     "id": 515,
@@ -5147,7 +5661,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2025 W OKLAHOMA AVE, SUITE 120",
-    "phone": "(414) 382-8960"
+    "phone": "(414) 382-8960",
+    "premium_savings": 0
   },
   {
     "id": 516,
@@ -5157,7 +5672,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "6026 W LISBON AVE",
-    "phone": "(414) 442-3630"
+    "phone": "(414) 442-3630",
+    "premium_savings": 5
   },
   {
     "id": 517,
@@ -5167,7 +5683,8 @@
     "city": "WEST BEND",
     "state": "WI",
     "address": "1100 GATEWAY CT",
-    "phone": "(262) 335-8600"
+    "phone": "(262) 335-8600",
+    "premium_savings": 10
   },
   {
     "id": 518,
@@ -5177,7 +5694,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "W129N7055 NORTHFIELD DR",
-    "phone": "(414) 805-5235"
+    "phone": "(414) 805-5235",
+    "premium_savings": 15
   },
   {
     "id": 519,
@@ -5187,7 +5705,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY, STE 630",
-    "phone": "(414) 385-1922"
+    "phone": "(414) 385-1922",
+    "premium_savings": 20
   },
   {
     "id": 520,
@@ -5197,7 +5716,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2900 W OKLAHOMA AVE",
-    "phone": "(414) 649-6000"
+    "phone": "(414) 649-6000",
+    "premium_savings": 0
   },
   {
     "id": 521,
@@ -5207,7 +5727,8 @@
     "city": "WEST BEND",
     "state": "WI",
     "address": "3200 PLEASANT VALLEY RD",
-    "phone": "(262) 836-7300"
+    "phone": "(262) 836-7300",
+    "premium_savings": 5
   },
   {
     "id": 522,
@@ -5217,7 +5738,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC PKWY, SUITE 570",
-    "phone": "(414) 385-8780"
+    "phone": "(414) 385-8780",
+    "premium_savings": 10
   },
   {
     "id": 523,
@@ -5227,7 +5749,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DEPARTMENT OF NEUROLOGY",
-    "phone": "(414) 805-5200"
+    "phone": "(414) 805-5200",
+    "premium_savings": 15
   },
   {
     "id": 524,
@@ -5237,7 +5760,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-8710"
+    "phone": "(414) 805-8710",
+    "premium_savings": 20
   },
   {
     "id": 525,
@@ -5247,7 +5771,8 @@
     "city": "MENOMONEE FALLS",
     "state": "WI",
     "address": "N84W16889 MENOMONEE AVE",
-    "phone": "(262) 251-7500"
+    "phone": "(262) 251-7500",
+    "premium_savings": 0
   },
   {
     "id": 526,
@@ -5257,7 +5782,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DEPT OF NEUROLOGY",
-    "phone": "(414) 805-5200"
+    "phone": "(414) 805-5200",
+    "premium_savings": 5
   },
   {
     "id": 527,
@@ -5267,7 +5793,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY",
-    "phone": "(414) 385-1922"
+    "phone": "(414) 385-1922",
+    "premium_savings": 10
   },
   {
     "id": 528,
@@ -5277,7 +5804,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 680",
-    "phone": "(414) 385-1922"
+    "phone": "(414) 385-1922",
+    "premium_savings": 15
   },
   {
     "id": 529,
@@ -5287,7 +5815,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3003 W GOOD HOPE RD",
-    "phone": "(414) 352-3100"
+    "phone": "(414) 352-3100",
+    "premium_savings": 20
   },
   {
     "id": 530,
@@ -5297,7 +5826,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 0
   },
   {
     "id": 531,
@@ -5307,7 +5837,8 @@
     "city": "WEST BEND",
     "state": "WI",
     "address": "3200 PLEASANT VALLEY RD",
-    "phone": "(262) 836-7300"
+    "phone": "(262) 836-7300",
+    "premium_savings": 5
   },
   {
     "id": 532,
@@ -5317,7 +5848,8 @@
     "city": "GERMANTOWN",
     "state": "WI",
     "address": "W180N11070 RIVER LN",
-    "phone": "(262) 535-8400"
+    "phone": "(262) 535-8400",
+    "premium_savings": 10
   },
   {
     "id": 533,
@@ -5327,7 +5859,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, GYNECOLOGIC ONCOLOGY",
-    "phone": "(414) 805-6600"
+    "phone": "(414) 805-6600",
+    "premium_savings": 15
   },
   {
     "id": 534,
@@ -5337,7 +5870,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "1111 DELAFIELD ST STE 120",
-    "phone": "(262) 544-4411"
+    "phone": "(262) 544-4411",
+    "premium_savings": 20
   },
   {
     "id": 535,
@@ -5347,7 +5881,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-6644"
+    "phone": "(414) 805-6644",
+    "premium_savings": 0
   },
   {
     "id": 536,
@@ -5357,7 +5892,8 @@
     "city": "GERMANTOWN",
     "state": "WI",
     "address": "W180N11070 RIVER LN",
-    "phone": "(262) 535-8400"
+    "phone": "(262) 535-8400",
+    "premium_savings": 5
   },
   {
     "id": 537,
@@ -5367,7 +5903,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3003 W GOOD HOPE RD",
-    "phone": "(414) 352-3100"
+    "phone": "(414) 352-3100",
+    "premium_savings": 10
   },
   {
     "id": 538,
@@ -5377,7 +5914,8 @@
     "city": "WAUKESHA",
     "state": "WI",
     "address": "1111 DELAFIELD ST STE 120",
-    "phone": "(262) 544-4411"
+    "phone": "(262) 544-4411",
+    "premium_savings": 15
   },
   {
     "id": 539,
@@ -5387,7 +5925,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, GYNECOLOGIC ONCOLOGY",
-    "phone": "(414) 805-6600"
+    "phone": "(414) 805-6600",
+    "premium_savings": 20
   },
   {
     "id": 540,
@@ -5397,7 +5936,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "8905 W LINCOLN AVE",
-    "phone": "(414) 328-6000"
+    "phone": "(414) 328-6000",
+    "premium_savings": 0
   },
   {
     "id": 541,
@@ -5407,7 +5947,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "8905 W LINCOLN AVE, STE 405",
-    "phone": "(414) 329-5650"
+    "phone": "(414) 329-5650",
+    "premium_savings": 5
   },
   {
     "id": 542,
@@ -5417,7 +5958,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-7400"
+    "phone": "(414) 805-7400",
+    "premium_savings": 10
   },
   {
     "id": 543,
@@ -5427,7 +5969,8 @@
     "city": "HARTFORD",
     "state": "WI",
     "address": "1640 E SUMNER ST",
-    "phone": "(262) 670-4000"
+    "phone": "(262) 670-4000",
+    "premium_savings": 15
   },
   {
     "id": 544,
@@ -5437,7 +5980,8 @@
     "city": "GREENFIELD",
     "state": "WI",
     "address": "9000 W SURA LN",
-    "phone": "(262) 329-2225"
+    "phone": "(262) 329-2225",
+    "premium_savings": 20
   },
   {
     "id": 545,
@@ -5447,7 +5991,8 @@
     "city": "NEW BERLIN",
     "state": "WI",
     "address": "4805 S MOORLAND RD",
-    "phone": "(262) 798-7200"
+    "phone": "(262) 798-7200",
+    "premium_savings": 0
   },
   {
     "id": 546,
@@ -5457,7 +6002,8 @@
     "city": "GRAFTON",
     "state": "WI",
     "address": "975 PORT WASHINGTON RD",
-    "phone": "(262) 329-8300"
+    "phone": "(262) 329-8300",
+    "premium_savings": 5
   },
   {
     "id": 547,
@@ -5467,7 +6013,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 303-5055"
+    "phone": "(262) 303-5055",
+    "premium_savings": 10
   },
   {
     "id": 548,
@@ -5477,7 +6024,8 @@
     "city": "GERMANTOWN",
     "state": "WI",
     "address": "W180N11070 RIVER LN",
-    "phone": "(262) 532-9700"
+    "phone": "(262) 532-9700",
+    "premium_savings": 15
   },
   {
     "id": 549,
@@ -5487,7 +6035,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 303-5055"
+    "phone": "(262) 303-5055",
+    "premium_savings": 20
   },
   {
     "id": 550,
@@ -5497,7 +6046,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "525 W RIVER WOODS PARKWAY, STE 130",
-    "phone": "(414) 961-0304"
+    "phone": "(414) 961-0304",
+    "premium_savings": 0
   },
   {
     "id": 551,
@@ -5507,7 +6057,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-7410"
+    "phone": "(414) 805-7410",
+    "premium_savings": 5
   },
   {
     "id": 552,
@@ -5517,7 +6068,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 544-5311"
+    "phone": "(262) 544-5311",
+    "premium_savings": 10
   },
   {
     "id": 553,
@@ -5527,7 +6079,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "525 W RIVER WOODS PKWY STE 100",
-    "phone": "(414) 332-6262"
+    "phone": "(414) 332-6262",
+    "premium_savings": 15
   },
   {
     "id": 554,
@@ -5537,7 +6090,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "2500 N MAYFAIR RD, STE 500",
-    "phone": "(414) 257-2525"
+    "phone": "(414) 257-2525",
+    "premium_savings": 20
   },
   {
     "id": 555,
@@ -5547,7 +6101,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2323 N MAYFAIR RD, SUITE 300",
-    "phone": "(414) 384-6700"
+    "phone": "(414) 384-6700",
+    "premium_savings": 0
   },
   {
     "id": 556,
@@ -5557,7 +6112,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 303-5055"
+    "phone": "(262) 303-5055",
+    "premium_savings": 5
   },
   {
     "id": 557,
@@ -5567,7 +6123,8 @@
     "city": "GERMANTOWN",
     "state": "WI",
     "address": "W180N11070 RIVER LN",
-    "phone": "(262) 532-9700"
+    "phone": "(262) 532-9700",
+    "premium_savings": 10
   },
   {
     "id": 558,
@@ -5577,7 +6134,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-7100"
+    "phone": "(414) 805-7100",
+    "premium_savings": 15
   },
   {
     "id": 559,
@@ -5587,7 +6145,8 @@
     "city": "GRAFTON",
     "state": "WI",
     "address": "975 PORT WASHINGTON RD",
-    "phone": "(262) 329-1000"
+    "phone": "(262) 329-1000",
+    "premium_savings": 20
   },
   {
     "id": 560,
@@ -5597,7 +6156,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "2424 S 90TH ST STE 500",
-    "phone": "(414) 321-2255"
+    "phone": "(414) 321-2255",
+    "premium_savings": 0
   },
   {
     "id": 561,
@@ -5607,7 +6167,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "3077 N MAYFAIR RD STE 100",
-    "phone": "(414) 384-6700"
+    "phone": "(414) 384-6700",
+    "premium_savings": 5
   },
   {
     "id": 562,
@@ -5617,7 +6178,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 544-5311"
+    "phone": "(262) 544-5311",
+    "premium_savings": 10
   },
   {
     "id": 563,
@@ -5627,7 +6189,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 544-5311"
+    "phone": "(262) 544-5311",
+    "premium_savings": 15
   },
   {
     "id": 564,
@@ -5637,7 +6200,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "19475 W NORTH AVE, SUITE 201",
-    "phone": "(262) 395-4160"
+    "phone": "(262) 395-4160",
+    "premium_savings": 20
   },
   {
     "id": 565,
@@ -5647,7 +6211,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "525 W RIVER WOODS PKWY STE 100",
-    "phone": "(414) 332-6262"
+    "phone": "(414) 332-6262",
+    "premium_savings": 0
   },
   {
     "id": 566,
@@ -5657,7 +6222,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 303-5055"
+    "phone": "(262) 303-5055",
+    "premium_savings": 5
   },
   {
     "id": 567,
@@ -5667,7 +6233,8 @@
     "city": "GRAFTON",
     "state": "WI",
     "address": "975 PORT WASHINGTON RD",
-    "phone": "(262) 329-1000"
+    "phone": "(262) 329-1000",
+    "premium_savings": 10
   },
   {
     "id": 568,
@@ -5677,7 +6244,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "525 W RIVER WOODS PARKWAY, STE 130",
-    "phone": "(414) 961-0304"
+    "phone": "(414) 961-0304",
+    "premium_savings": 15
   },
   {
     "id": 569,
@@ -5687,7 +6255,8 @@
     "city": "GRAFTON",
     "state": "WI",
     "address": "975 PORT WASHINGTON ROAD, SUITE 110",
-    "phone": "(262) 387-8300"
+    "phone": "(262) 387-8300",
+    "premium_savings": 20
   },
   {
     "id": 570,
@@ -5697,7 +6266,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 370",
-    "phone": "(414) 649-7900"
+    "phone": "(414) 649-7900",
+    "premium_savings": 0
   },
   {
     "id": 571,
@@ -5707,7 +6277,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "525 W RIVER WOODS PKWY STE 100",
-    "phone": "(414) 332-6262"
+    "phone": "(414) 332-6262",
+    "premium_savings": 5
   },
   {
     "id": 572,
@@ -5717,7 +6288,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-7400"
+    "phone": "(414) 805-7400",
+    "premium_savings": 10
   },
   {
     "id": 573,
@@ -5727,7 +6299,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "2424 S 90TH ST, SUITE 500",
-    "phone": "(414) 328-8600"
+    "phone": "(414) 328-8600",
+    "premium_savings": 15
   },
   {
     "id": 574,
@@ -5737,7 +6310,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3237 S 16TH ST, SUITE 210",
-    "phone": "(414) 384-6700"
+    "phone": "(414) 384-6700",
+    "premium_savings": 20
   },
   {
     "id": 575,
@@ -5747,7 +6321,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "525 W RIVER WOODS PARKWAY, STE 130",
-    "phone": "(414) 961-0304"
+    "phone": "(414) 961-0304",
+    "premium_savings": 0
   },
   {
     "id": 576,
@@ -5757,7 +6332,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 544-5311"
+    "phone": "(262) 544-5311",
+    "premium_savings": 5
   },
   {
     "id": 577,
@@ -5767,7 +6343,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 303-5055"
+    "phone": "(262) 303-5055",
+    "premium_savings": 10
   },
   {
     "id": 578,
@@ -5777,7 +6354,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 544-5311"
+    "phone": "(262) 544-5311",
+    "premium_savings": 15
   },
   {
     "id": 579,
@@ -5787,7 +6365,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "2500 N MAYFAIR RD, SUITE 500",
-    "phone": "(414) 257-2525"
+    "phone": "(414) 257-2525",
+    "premium_savings": 20
   },
   {
     "id": 580,
@@ -5797,7 +6376,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 345",
-    "phone": "(414) 649-7900"
+    "phone": "(414) 649-7900",
+    "premium_savings": 0
   },
   {
     "id": 581,
@@ -5807,7 +6387,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-7400"
+    "phone": "(414) 805-7400",
+    "premium_savings": 5
   },
   {
     "id": 582,
@@ -5817,7 +6398,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "525 W RIVER WOODS PARKWAY, STE 130",
-    "phone": "(414) 961-0304"
+    "phone": "(414) 961-0304",
+    "premium_savings": 10
   },
   {
     "id": 583,
@@ -5827,7 +6409,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "525 W RIVER WOODS PKWY, SUITE 230",
-    "phone": "(414) 453-7418"
+    "phone": "(414) 453-7418",
+    "premium_savings": 15
   },
   {
     "id": 584,
@@ -5837,7 +6420,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 955-3222"
+    "phone": "(414) 955-3222",
+    "premium_savings": 20
   },
   {
     "id": 585,
@@ -5847,7 +6431,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 303-5055"
+    "phone": "(262) 303-5055",
+    "premium_savings": 0
   },
   {
     "id": 586,
@@ -5857,7 +6442,8 @@
     "city": "WEST ALLIS",
     "state": "WI",
     "address": "2424 S 90TH ST",
-    "phone": "(414) 321-2255"
+    "phone": "(414) 321-2255",
+    "premium_savings": 5
   },
   {
     "id": 587,
@@ -5867,7 +6453,8 @@
     "city": "WAUWATOSA",
     "state": "WI",
     "address": "3077 N MAYFAIR RD STE 100",
-    "phone": "(414) 384-6700"
+    "phone": "(414) 384-6700",
+    "premium_savings": 10
   },
   {
     "id": 588,
@@ -5877,7 +6464,8 @@
     "city": "PEWAUKEE",
     "state": "WI",
     "address": "N15W28300 GOLF RD",
-    "phone": "(262) 544-5311"
+    "phone": "(262) 544-5311",
+    "premium_savings": 15
   },
   {
     "id": 589,
@@ -5887,7 +6475,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "3237 S 16TH ST, SUITE 210",
-    "phone": "(414) 384-6700"
+    "phone": "(414) 384-6700",
+    "premium_savings": 20
   },
   {
     "id": 590,
@@ -5897,7 +6486,8 @@
     "city": "WEST BEND",
     "state": "WI",
     "address": "1700 W PARADISE DR, ORTHOPAEDIC SURGERY",
-    "phone": "(262) 334-3451"
+    "phone": "(262) 334-3451",
+    "premium_savings": 0
   },
   {
     "id": 591,
@@ -5907,7 +6497,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 5
   },
   {
     "id": 592,
@@ -5917,7 +6508,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "1414 N TAYLOR DR STE 110",
-    "phone": "(920) 320-5241"
+    "phone": "(920) 320-5241",
+    "premium_savings": 10
   },
   {
     "id": 593,
@@ -5927,7 +6519,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE, DIVISION OF RHEUMATOLOGY",
-    "phone": "(414) 805-6655"
+    "phone": "(414) 805-6655",
+    "premium_savings": 15
   },
   {
     "id": 594,
@@ -5937,7 +6530,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "7080 N PORT WASHINGTON ROAD",
-    "phone": "(414) 351-4009"
+    "phone": "(414) 351-4009",
+    "premium_savings": 20
   },
   {
     "id": 595,
@@ -5947,7 +6541,8 @@
     "city": "FRANKLIN",
     "state": "WI",
     "address": "4225 W OAKWOOD PARK CT",
-    "phone": "(414) 435-0025"
+    "phone": "(414) 435-0025",
+    "premium_savings": 0
   },
   {
     "id": 596,
@@ -5957,7 +6552,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "7080 N PORT WASHINGTON RD, RHEUMATIC DISEASE CENTER",
-    "phone": "(414) 351-4009"
+    "phone": "(414) 351-4009",
+    "premium_savings": 5
   },
   {
     "id": 597,
@@ -5967,7 +6563,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9200 W WISCONSIN AVE",
-    "phone": "(414) 805-7390"
+    "phone": "(414) 805-7390",
+    "premium_savings": 10
   },
   {
     "id": 598,
@@ -5977,7 +6574,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "601 N BARKER RD, 110",
-    "phone": "(262) 785-0777"
+    "phone": "(262) 785-0777",
+    "premium_savings": 15
   },
   {
     "id": 599,
@@ -5987,7 +6585,8 @@
     "city": "FRANKLIN",
     "state": "WI",
     "address": "4225 W. OAKWOOD PARK CT",
-    "phone": "(414) 435-0025"
+    "phone": "(414) 435-0025",
+    "premium_savings": 20
   },
   {
     "id": 600,
@@ -5997,7 +6596,8 @@
     "city": "BROOKFIELD",
     "state": "WI",
     "address": "601 N BARKER RD, 110",
-    "phone": "(262) 785-0777"
+    "phone": "(262) 785-0777",
+    "premium_savings": 0
   },
   {
     "id": 601,
@@ -6007,7 +6607,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "7080 N PORT WASHINGTON RD",
-    "phone": "(414) 351-4009"
+    "phone": "(414) 351-4009",
+    "premium_savings": 5
   },
   {
     "id": 602,
@@ -6017,7 +6618,8 @@
     "city": "GLENDALE",
     "state": "WI",
     "address": "7080 N PORT WASHINGTON RD",
-    "phone": "(414) 351-4009"
+    "phone": "(414) 351-4009",
+    "premium_savings": 10
   },
   {
     "id": 603,
@@ -6027,7 +6629,8 @@
     "city": "HUDSON",
     "state": "WI",
     "address": "2651 HILLCREST DR STE 301",
-    "phone": "(651) 333-2190"
+    "phone": "(651) 333-2190",
+    "premium_savings": 15
   },
   {
     "id": 604,
@@ -6037,7 +6640,8 @@
     "city": "GREEN BAY",
     "state": "WI",
     "address": "3263 EATON RD",
-    "phone": "(920) 433-6700"
+    "phone": "(920) 433-6700",
+    "premium_savings": 20
   },
   {
     "id": 605,
@@ -6047,7 +6651,8 @@
     "city": "NEENAH",
     "state": "WI",
     "address": "1265 W AMERICAN DR STE 200",
-    "phone": "(920) 722-7747"
+    "phone": "(920) 722-7747",
+    "premium_savings": 0
   },
   {
     "id": 606,
@@ -6057,7 +6662,8 @@
     "city": "NEENAH",
     "state": "WI",
     "address": "1205 W AMERICAN DR",
-    "phone": "(920) 965-6382"
+    "phone": "(920) 965-6382",
+    "premium_savings": 5
   },
   {
     "id": 607,
@@ -6067,7 +6673,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "1506 S ONEIDA ST",
-    "phone": "(920) 730-2640"
+    "phone": "(920) 730-2640",
+    "premium_savings": 10
   },
   {
     "id": 608,
@@ -6077,7 +6684,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "2700 W 9TH AVE, STE 106",
-    "phone": "(920) 236-1750"
+    "phone": "(920) 236-1750",
+    "premium_savings": 15
   },
   {
     "id": 609,
@@ -6087,7 +6695,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "515 S WASHBURN ST, SUITE 204",
-    "phone": "(920) 232-1130"
+    "phone": "(920) 232-1130",
+    "premium_savings": 20
   },
   {
     "id": 610,
@@ -6097,7 +6706,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 0
   },
   {
     "id": 611,
@@ -6107,7 +6717,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "515 S WASHBURN ST, SUITE 204",
-    "phone": "(920) 232-1130"
+    "phone": "(920) 232-1130",
+    "premium_savings": 5
   },
   {
     "id": 612,
@@ -6117,7 +6728,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "2351 STATE ROAD 44",
-    "phone": "(920) 651-8855"
+    "phone": "(920) 651-8855",
+    "premium_savings": 10
   },
   {
     "id": 613,
@@ -6127,7 +6739,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "855 N WESTHAVEN DR",
-    "phone": "(920) 303-8700"
+    "phone": "(920) 303-8700",
+    "premium_savings": 15
   },
   {
     "id": 614,
@@ -6137,7 +6750,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "2700 W 9TH AVE, SUITE 300",
-    "phone": "(920) 223-0490"
+    "phone": "(920) 223-0490",
+    "premium_savings": 20
   },
   {
     "id": 615,
@@ -6147,7 +6761,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "2700 W 9TH AVE, SUITE315A",
-    "phone": "(920) 236-1630"
+    "phone": "(920) 236-1630",
+    "premium_savings": 0
   },
   {
     "id": 616,
@@ -6157,7 +6772,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 5
   },
   {
     "id": 617,
@@ -6167,7 +6783,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "855 N WESTHAVEN DR",
-    "phone": "(920) 303-8700"
+    "phone": "(920) 303-8700",
+    "premium_savings": 10
   },
   {
     "id": 618,
@@ -6177,7 +6794,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "2500 E CAPITOL DR",
-    "phone": "(920) 364-3600"
+    "phone": "(920) 364-3600",
+    "premium_savings": 15
   },
   {
     "id": 619,
@@ -6187,7 +6805,8 @@
     "city": "NEENAH",
     "state": "WI",
     "address": "1305 W AMERICAN DR",
-    "phone": "(920) 725-9373"
+    "phone": "(920) 725-9373",
+    "premium_savings": 20
   },
   {
     "id": 620,
@@ -6197,7 +6816,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "2700 W 9TH AVE, SUITE 203",
-    "phone": "(920) 223-2727"
+    "phone": "(920) 223-2727",
+    "premium_savings": 0
   },
   {
     "id": 621,
@@ -6207,7 +6827,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "855 N WESTHAVEN DR",
-    "phone": "(920) 303-8700"
+    "phone": "(920) 303-8700",
+    "premium_savings": 5
   },
   {
     "id": 622,
@@ -6217,7 +6838,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 10
   },
   {
     "id": 623,
@@ -6227,7 +6849,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "855 N WESTHAVEN DR",
-    "phone": "(920) 303-8700"
+    "phone": "(920) 303-8700",
+    "premium_savings": 15
   },
   {
     "id": 624,
@@ -6237,7 +6860,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "2700 W 9TH AVE STE 125",
-    "phone": "(800) 322-2141"
+    "phone": "(800) 322-2141",
+    "premium_savings": 20
   },
   {
     "id": 625,
@@ -6247,7 +6871,8 @@
     "city": "NEENAH",
     "state": "WI",
     "address": "1205 W AMERICAN DR",
-    "phone": "(920) 430-8113"
+    "phone": "(920) 430-8113",
+    "premium_savings": 0
   },
   {
     "id": 626,
@@ -6257,7 +6882,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "855 N WESTHAVEN DR",
-    "phone": "(920) 303-8700"
+    "phone": "(920) 303-8700",
+    "premium_savings": 5
   },
   {
     "id": 627,
@@ -6267,7 +6893,8 @@
     "city": "APPLETON",
     "state": "WI",
     "address": "5320 W MICHAELS DR",
-    "phone": "(920) 882-8200"
+    "phone": "(920) 882-8200",
+    "premium_savings": 10
   },
   {
     "id": 628,
@@ -6277,7 +6904,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "2700 W 9TH AVE STE 125",
-    "phone": "(920) 430-8113"
+    "phone": "(920) 430-8113",
+    "premium_savings": 15
   },
   {
     "id": 629,
@@ -6287,7 +6915,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "855 N WESTHAVEN DR",
-    "phone": "(920) 303-8700"
+    "phone": "(920) 303-8700",
+    "premium_savings": 20
   },
   {
     "id": 630,
@@ -6297,7 +6926,8 @@
     "city": "NEENAH",
     "state": "WI",
     "address": "1205 WEST AMERICAN DRIVE",
-    "phone": "(920) 430-8113"
+    "phone": "(920) 430-8113",
+    "premium_savings": 0
   },
   {
     "id": 631,
@@ -6307,7 +6937,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "2700 W 9TH AVE STE 125",
-    "phone": "(920) 430-8113"
+    "phone": "(920) 430-8113",
+    "premium_savings": 5
   },
   {
     "id": 632,
@@ -6317,7 +6948,8 @@
     "city": "NEENAH",
     "state": "WI",
     "address": "200 THEDA CLARK MEDICAL PLZ STE 240",
-    "phone": "(920) 729-2710"
+    "phone": "(920) 729-2710",
+    "premium_savings": 10
   },
   {
     "id": 633,
@@ -6327,7 +6959,8 @@
     "city": "OSHKOSH",
     "state": "WI",
     "address": "855 N WESTHAVEN DR",
-    "phone": "(920) 303-8700"
+    "phone": "(920) 303-8700",
+    "premium_savings": 15
   },
   {
     "id": 634,
@@ -6337,7 +6970,8 @@
     "city": "STURTEVANT",
     "state": "WI",
     "address": "10340 WASHINGTON AVE STE 100",
-    "phone": "(414) 908-6500"
+    "phone": "(414) 908-6500",
+    "premium_savings": 20
   },
   {
     "id": 635,
@@ -6347,7 +6981,8 @@
     "city": "MUKWONAGO",
     "state": "WI",
     "address": "240 MAPLE AVE STE 2220",
-    "phone": "(414) 454-0600"
+    "phone": "(414) 454-0600",
+    "premium_savings": 0
   },
   {
     "id": 636,
@@ -6357,7 +6992,8 @@
     "city": "RACINE",
     "state": "WI",
     "address": "3803 SPRING ST",
-    "phone": "(262) 687-3973"
+    "phone": "(262) 687-3973",
+    "premium_savings": 5
   },
   {
     "id": 637,
@@ -6367,7 +7003,8 @@
     "city": "MUKWONAGO",
     "state": "WI",
     "address": "240 MAPLE AVE",
-    "phone": "(262) 928-8800"
+    "phone": "(262) 928-8800",
+    "premium_savings": 10
   },
   {
     "id": 638,
@@ -6377,7 +7014,8 @@
     "city": "RACINE",
     "state": "WI",
     "address": "1151 WARWICK WAY",
-    "phone": "(262) 321-6300"
+    "phone": "(262) 321-6300",
+    "premium_savings": 15
   },
   {
     "id": 639,
@@ -6387,7 +7025,8 @@
     "city": "MOUNT PLEASANT",
     "state": "WI",
     "address": "1300 S GREEN BAY RD STE 100",
-    "phone": "(262) 619-4191"
+    "phone": "(262) 619-4191",
+    "premium_savings": 20
   },
   {
     "id": 640,
@@ -6397,7 +7036,8 @@
     "city": "MOUNT PLEASANT",
     "state": "WI",
     "address": "1300 S GREEN BAY RD, SUITE 100",
-    "phone": "(262) 619-4191"
+    "phone": "(262) 619-4191",
+    "premium_savings": 0
   },
   {
     "id": 641,
@@ -6407,7 +7047,8 @@
     "city": "MOUNT PLEASANT",
     "state": "WI",
     "address": "3807 SPRING ST STE 310",
-    "phone": "(262) 687-8115"
+    "phone": "(262) 687-8115",
+    "premium_savings": 5
   },
   {
     "id": 642,
@@ -6417,7 +7058,8 @@
     "city": "MOUNT PLEASANT",
     "state": "WI",
     "address": "3805A SPRING ST",
-    "phone": "(262) 687-8115"
+    "phone": "(262) 687-8115",
+    "premium_savings": 10
   },
   {
     "id": 643,
@@ -6427,7 +7069,8 @@
     "city": "KENOSHA",
     "state": "WI",
     "address": "10400 75TH ST",
-    "phone": "(262) 948-7000"
+    "phone": "(262) 948-7000",
+    "premium_savings": 15
   },
   {
     "id": 644,
@@ -6437,7 +7080,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "2801 W KINNICKINNIC RIVER PKWY STE 1080",
-    "phone": "(414) 908-6601"
+    "phone": "(414) 908-6601",
+    "premium_savings": 20
   },
   {
     "id": 645,
@@ -6447,7 +7091,8 @@
     "city": "MOUNT PLEASANT",
     "state": "WI",
     "address": "8400 WASHINGTON AVE",
-    "phone": "(262) 884-8340"
+    "phone": "(262) 884-8340",
+    "premium_savings": 0
   },
   {
     "id": 646,
@@ -6457,7 +7102,8 @@
     "city": "MOUNT PLEASANT",
     "state": "WI",
     "address": "8400 WASHINGTON AVE",
-    "phone": "(262) 884-8340"
+    "phone": "(262) 884-8340",
+    "premium_savings": 5
   },
   {
     "id": 647,
@@ -6467,7 +7113,8 @@
     "city": "MOUNT PLEASANT",
     "state": "WI",
     "address": "3805B SPRING ST",
-    "phone": "(262) 687-8322"
+    "phone": "(262) 687-8322",
+    "premium_savings": 10
   },
   {
     "id": 648,
@@ -6477,7 +7124,8 @@
     "city": "MOUNT PLEASANT",
     "state": "WI",
     "address": "13250 WASHINGTON AVE",
-    "phone": "(888) 720-2012"
+    "phone": "(888) 720-2012",
+    "premium_savings": 15
   },
   {
     "id": 649,
@@ -6487,7 +7135,8 @@
     "city": "OAK CREEK",
     "state": "WI",
     "address": "200 E RYAN RD",
-    "phone": "(414) 570-3590"
+    "phone": "(414) 570-3590",
+    "premium_savings": 20
   },
   {
     "id": 650,
@@ -6497,7 +7146,8 @@
     "city": "OCONOMOWOC",
     "state": "WI",
     "address": "1185 CORPORATE CTR DR",
-    "phone": "(262) 785-0777"
+    "phone": "(262) 785-0777",
+    "premium_savings": 0
   },
   {
     "id": 651,
@@ -6507,7 +7157,8 @@
     "city": "PLYMOUTH",
     "state": "WI",
     "address": "2631 EASTERN AVE",
-    "phone": "(920) 476-6350"
+    "phone": "(920) 476-6350",
+    "premium_savings": 5
   },
   {
     "id": 652,
@@ -6517,7 +7168,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "1414 N TAYLOR DR",
-    "phone": "(920) 458-9800"
+    "phone": "(920) 458-9800",
+    "premium_savings": 10
   },
   {
     "id": 653,
@@ -6527,7 +7179,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "2414 KOHLER MEMORIAL DR",
-    "phone": "(920) 457-4461"
+    "phone": "(920) 457-4461",
+    "premium_savings": 15
   },
   {
     "id": 654,
@@ -6537,7 +7190,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "2414 KOHLER MEMORIAL DR",
-    "phone": "(920) 457-4461"
+    "phone": "(920) 457-4461",
+    "premium_savings": 20
   },
   {
     "id": 655,
@@ -6547,7 +7201,8 @@
     "city": "MADISON",
     "state": "WI",
     "address": "451 JUNCTION RD",
-    "phone": "(608) 263-5010"
+    "phone": "(608) 263-5010",
+    "premium_savings": 0
   },
   {
     "id": 656,
@@ -6557,7 +7212,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "2414 KOHLER MEMORIAL DR",
-    "phone": "(920) 457-4461"
+    "phone": "(920) 457-4461",
+    "premium_savings": 5
   },
   {
     "id": 657,
@@ -6567,7 +7223,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "1222 N 23RD ST",
-    "phone": "(920) 457-6800"
+    "phone": "(920) 457-6800",
+    "premium_savings": 10
   },
   {
     "id": 658,
@@ -6577,7 +7234,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "1621 N TAYLOR DR, SUITE 100",
-    "phone": "(920) 458-7433"
+    "phone": "(920) 458-7433",
+    "premium_savings": 15
   },
   {
     "id": 659,
@@ -6587,7 +7245,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "1222 N 23RD ST",
-    "phone": "(920) 457-6800"
+    "phone": "(920) 457-6800",
+    "premium_savings": 20
   },
   {
     "id": 660,
@@ -6597,7 +7256,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "2414 KOHLER MEMORIAL DR",
-    "phone": "(920) 457-4461"
+    "phone": "(920) 457-4461",
+    "premium_savings": 0
   },
   {
     "id": 661,
@@ -6607,7 +7267,8 @@
     "city": "SHEBOYGAN",
     "state": "WI",
     "address": "2414 KOHLER MEMORIAL DR",
-    "phone": "(920) 457-4461"
+    "phone": "(920) 457-4461",
+    "premium_savings": 5
   },
   {
     "id": 662,
@@ -6617,7 +7278,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "225000 HUMMINGBIRD RD STE 300",
-    "phone": "(715) 359-7592"
+    "phone": "(715) 359-7592",
+    "premium_savings": 10
   },
   {
     "id": 663,
@@ -6627,7 +7289,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "2727 PLAZA DR",
-    "phone": "(715) 847-3000"
+    "phone": "(715) 847-3000",
+    "premium_savings": 15
   },
   {
     "id": 664,
@@ -6637,7 +7300,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "411 WESTWOOD DR",
-    "phone": "(715) 847-2558"
+    "phone": "(715) 847-2558",
+    "premium_savings": 20
   },
   {
     "id": 665,
@@ -6647,7 +7311,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "2727 PLAZA DR",
-    "phone": "(715) 847-3000"
+    "phone": "(715) 847-3000",
+    "premium_savings": 0
   },
   {
     "id": 666,
@@ -6657,7 +7322,8 @@
     "city": "WESTON",
     "state": "WI",
     "address": "3400 MINISTRY PKWY",
-    "phone": "(715) 393-1220"
+    "phone": "(715) 393-1220",
+    "premium_savings": 5
   },
   {
     "id": 667,
@@ -6667,7 +7333,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "500 WIND RIDGE DR",
-    "phone": "(715) 847-2611"
+    "phone": "(715) 847-2611",
+    "premium_savings": 10
   },
   {
     "id": 668,
@@ -6677,7 +7344,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "425 PINE RIDGE BLVD STE 305A",
-    "phone": "(715) 847-2626"
+    "phone": "(715) 847-2626",
+    "premium_savings": 15
   },
   {
     "id": 669,
@@ -6687,7 +7355,8 @@
     "city": "RHINELANDER",
     "state": "WI",
     "address": "550 E TIMBER DR",
-    "phone": "(715) 369-4500"
+    "phone": "(715) 369-4500",
+    "premium_savings": 20
   },
   {
     "id": 670,
@@ -6697,7 +7366,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "510 N 17TH AVE STE C",
-    "phone": "(715) 849-5333"
+    "phone": "(715) 849-5333",
+    "premium_savings": 0
   },
   {
     "id": 671,
@@ -6707,7 +7377,8 @@
     "city": "WESTON",
     "state": "WI",
     "address": "3501 CRANBERRY BLVD",
-    "phone": "(715) 393-1000"
+    "phone": "(715) 393-1000",
+    "premium_savings": 5
   },
   {
     "id": 672,
@@ -6717,7 +7388,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "411 WESTWOOD DR",
-    "phone": "(715) 847-2558"
+    "phone": "(715) 847-2558",
+    "premium_savings": 10
   },
   {
     "id": 673,
@@ -6727,7 +7399,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "411 WESTWOOD DR",
-    "phone": "(715) 847-2558"
+    "phone": "(715) 847-2558",
+    "premium_savings": 15
   },
   {
     "id": 674,
@@ -6737,7 +7410,8 @@
     "city": "WESTON",
     "state": "WI",
     "address": "3501 CRANBERRY BLVD",
-    "phone": "(715) 393-1000"
+    "phone": "(715) 393-1000",
+    "premium_savings": 20
   },
   {
     "id": 675,
@@ -6747,7 +7421,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "411 WESTWOOD DR",
-    "phone": "(715) 847-2558"
+    "phone": "(715) 847-2558",
+    "premium_savings": 0
   },
   {
     "id": 676,
@@ -6757,7 +7432,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "411 WESTWOOD DR",
-    "phone": "(715) 847-2558"
+    "phone": "(715) 847-2558",
+    "premium_savings": 5
   },
   {
     "id": 677,
@@ -6767,7 +7443,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "411 WESTWOOD DR",
-    "phone": "(715) 847-2558"
+    "phone": "(715) 847-2558",
+    "premium_savings": 10
   },
   {
     "id": 678,
@@ -6777,7 +7454,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "333 PINE RIDGE BLVD",
-    "phone": "(715) 847-2866"
+    "phone": "(715) 847-2866",
+    "premium_savings": 15
   },
   {
     "id": 679,
@@ -6787,7 +7465,8 @@
     "city": "WESTON",
     "state": "WI",
     "address": "3501 CRANBERRY BLVD",
-    "phone": "(715) 393-1000"
+    "phone": "(715) 393-1000",
+    "premium_savings": 20
   },
   {
     "id": 680,
@@ -6797,7 +7476,8 @@
     "city": "MILWAUKEE",
     "state": "WI",
     "address": "9000 W WISCONSIN AVE",
-    "phone": "(414) 266-3464"
+    "phone": "(414) 266-3464",
+    "premium_savings": 0
   },
   {
     "id": 681,
@@ -6807,7 +7487,8 @@
     "city": "FORT ATKINSON",
     "state": "WI",
     "address": "650 MCMILLEN ST",
-    "phone": "(920) 563-8900"
+    "phone": "(920) 563-8900",
+    "premium_savings": 5
   },
   {
     "id": 682,
@@ -6817,7 +7498,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "2720 PLAZA DR, SUITE # 2100",
-    "phone": "(715) 847-2475"
+    "phone": "(715) 847-2475",
+    "premium_savings": 10
   },
   {
     "id": 683,
@@ -6827,7 +7509,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "225000 HUMMINGBIRD RD STE 100",
-    "phone": "(715) 359-6442"
+    "phone": "(715) 359-6442",
+    "premium_savings": 15
   },
   {
     "id": 684,
@@ -6837,7 +7520,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "225000 HUMMINGBIRD RD STE 100",
-    "phone": "(715) 359-6442"
+    "phone": "(715) 359-6442",
+    "premium_savings": 20
   },
   {
     "id": 685,
@@ -6847,7 +7531,8 @@
     "city": null,
     "state": null,
     "address": null,
-    "phone": null
+    "phone": null,
+    "premium_savings": 0
   },
   {
     "id": 686,
@@ -6857,7 +7542,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "225000 HUMMINGBIRD RD STE 100",
-    "phone": "(800) 445-6442"
+    "phone": "(800) 445-6442",
+    "premium_savings": 5
   },
   {
     "id": 687,
@@ -6867,7 +7553,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "3901 STEWART AVE",
-    "phone": "(715) 907-0900"
+    "phone": "(715) 907-0900",
+    "premium_savings": 10
   },
   {
     "id": 688,
@@ -6877,7 +7564,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "225000 HUMMINGBIRD RD STE 100",
-    "phone": "(715) 359-6442"
+    "phone": "(715) 359-6442",
+    "premium_savings": 15
   },
   {
     "id": 689,
@@ -6887,7 +7575,8 @@
     "city": "WESTON",
     "state": "WI",
     "address": "3501 CRANBERRY BLVD",
-    "phone": "(715) 387-5202"
+    "phone": "(715) 387-5202",
+    "premium_savings": 20
   },
   {
     "id": 690,
@@ -6897,7 +7586,8 @@
     "city": "RHINELANDER",
     "state": "WI",
     "address": "444 E TIMBER DR",
-    "phone": "(715) 369-2300"
+    "phone": "(715) 369-2300",
+    "premium_savings": 0
   },
   {
     "id": 691,
@@ -6907,7 +7597,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "3901 STEWART AVE",
-    "phone": "(715) 907-0900"
+    "phone": "(715) 907-0900",
+    "premium_savings": 5
   },
   {
     "id": 692,
@@ -6917,7 +7608,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "225000 HUMMINGBIRD RD STE 100",
-    "phone": "(715) 359-6442"
+    "phone": "(715) 359-6442",
+    "premium_savings": 10
   },
   {
     "id": 693,
@@ -6927,7 +7619,8 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "2727 PLAZA DR",
-    "phone": "(715) 847-3563"
+    "phone": "(715) 847-3563",
+    "premium_savings": 15
   },
   {
     "id": 694,
@@ -6937,6 +7630,7 @@
     "city": "WAUSAU",
     "state": "WI",
     "address": "2720 PLAZA DR STE 1400A",
-    "phone": "(715) 847-0426"
+    "phone": "(715) 847-0426",
+    "premium_savings": 20
   }
 ]

--- a/results.html
+++ b/results.html
@@ -164,6 +164,7 @@
       let items = DOCTORS.slice();
       if (specialty) items = items.filter(d => d.specialty === specialty);
       if (zip) items = items.filter(d => d.zip === zip);
+      items.sort((a, b) => (b.premium_savings || 0) - (a.premium_savings || 0));
 
       summary.textContent = `${items.length} result${items.length===1?'':'s'}${specialty?` · ${specialty}`:''}${zip?` · ${zip}`:''}`;
 
@@ -173,13 +174,14 @@
       items.forEach(d => {
         const el = document.createElement('article');
         el.className = 'rounded-2xl border bg-white p-5 shadow-sm';
+        const savingsTag = d.premium_savings ? `<p class="text-sm mt-1"><span class="inline-flex items-center bg-saveWine text-white text-xs font-semibold px-2 py-0.5 rounded-full">$${d.premium_savings} premium savings per visit</span></p>` : '';
         el.innerHTML = `
           <div class="flex items-start justify-between gap-4">
             <div>
               <h2 class="font-semibold text-lg">${d.name}</h2>
               <p class="text-sm text-slate-600">${d.specialty}</p>
               <p class="text-sm text-slate-500">${d.address}<br>${d.city}, ${d.state} ${d.zip}</p>
-              <p class="text-sm mt-1"><span class="inline-flex items-center bg-saveWine text-white text-xs font-semibold px-2 py-0.5 rounded-full">$5 premium savings per visit</span></p>
+              ${savingsTag}
             </div>
             <a href="tel:${d.phone.replace(/[^0-9]/g,'')}" class="shrink-0 rounded-xl bg-saveTeal px-4 py-2 text-white text-sm font-semibold hover:bg-saveTealDark">Call</a>
           </div>`;


### PR DESCRIPTION
## Summary
- add `premium_savings` to every provider document
- sort search results by premium savings and show tag only for positive values

## Testing
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('data/providers.json','utf8'));console.log('providers.json valid')"`


------
https://chatgpt.com/codex/tasks/task_e_68b8970d35108326911bc9a1b6e5a96d