### PR TITLE
Handle providers missing phone numbers

### DIFF
--- a/results.html
+++ b/results.html
@@ -182,7 +182,16 @@
       items.forEach(d => {
         const el = document.createElement('article');
         el.className = 'rounded-2xl border bg-white p-5 shadow-sm';
-        const savingsTag = (d.premium_savings || 0) > 0 ? `<p class="text-sm mt-1"><span class="inline-flex items-center bg-saveWine text-white text-xs font-semibold px-2 py-0.5 rounded-full">$${d.premium_savings} premium savings per visit</span></p>` : '';
+        const savingsTag = (d.premium_savings || 0) > 0
+          ? `<p class="text-sm mt-1"><span class="inline-flex items-center bg-saveWine text-white text-xs font-semibold px-2 py-0.5 rounded-full">$${d.premium_savings} premium savings per visit</span></p>`
+          : '';
+
+        // Some providers don't have phone numbers. Build the call link only when one exists
+        const phoneDigits = (d.phone || '').replace(/[^0-9]/g, '');
+        const callLink = phoneDigits
+          ? `<a href="tel:${phoneDigits}" class="shrink-0 rounded-xl bg-saveTeal px-4 py-2 text-white text-sm font-semibold hover:bg-saveTealDark">Call</a>`
+          : '';
+
         el.innerHTML = `
           <div class="flex items-start justify-between gap-4">
             <div>
@@ -191,7 +200,7 @@
               <p class="text-sm text-slate-500">${d.address}<br>${d.city}, ${d.state} ${d.zip}</p>
               ${savingsTag}
             </div>
-            <a href="tel:${d.phone.replace(/[^0-9]/g,'')}" class="shrink-0 rounded-xl bg-saveTeal px-4 py-2 text-white text-sm font-semibold hover:bg-saveTealDark">Call</a>
+            ${callLink}
           </div>`;
         results.appendChild(el);
       });


### PR DESCRIPTION
## Summary
- Render call button only when a provider phone number exists
- Prevent search results rendering from stopping when encountering missing phone numbers

## Testing
- `node - <<'NODE'
const fs = require('fs');
const data = JSON.parse(fs.readFileSync('data/providers.json'));
let items = data.filter(d => d.specialty === 'Dermatology');
items.sort((a, b) => (Number(b.premium_savings) || 0) - (Number(a.premium_savings) || 0) || (a.name || '').localeCompare(b.name || ''));
let count = 0;
for (const d of items) {
  const savingsTag = (d.premium_savings || 0) > 0 ? 'tag' : '';
  const phoneDigits = (d.phone || '').replace(/[^0-9]/g, '');
  const callLink = phoneDigits ? `tel:${phoneDigits}` : '';
  const html = `<div>${d.name}${savingsTag}${callLink}</div>`;
  count++;
}
console.log('rendered', count);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b8c45469848326b29bace2113124a5