### PR TITLE
Fix search button alignment on results page

### DIFF
--- a/results.html
+++ b/results.html
@@ -47,8 +47,8 @@
     <!-- Search again bar -->
     <section class="bg-slate-50 border-b border-slate-200">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
-        <form action="results.html" method="get" class="bg-white border rounded-2xl p-3 grid grid-cols-1 sm:grid-cols-5 gap-3">
-          <select name="specialty" id="specialty" class="sm:col-span-2 rounded-xl border-slate-300 focus:border-saveWine focus:ring-saveWine py-3">
+        <form action="results.html" method="get" class="bg-white border rounded-2xl p-3 flex flex-col sm:flex-row gap-3">
+          <select name="specialty" id="specialty" class="w-full sm:w-1/3 rounded-xl border-slate-300 focus:border-saveWine focus:ring-saveWine py-3">
             <option value="">All specialties</option>
             <option>Ambulatory Surgical Center</option>
             <option>Cardiology</option>
@@ -61,8 +61,8 @@
             <option>Orthopedic Surgery</option>
             <option>Rheumatology</option>
           </select>
-          <input name="zip" id="zip" placeholder="ZIP code" pattern="\d{5}" class="sm:col-span-2 rounded-xl border-slate-300 focus:border-saveWine focus:ring-saveWine py-3 px-3" />
-          <button class="sm:col-span-1 rounded-xl bg-saveTeal text-white font-semibold px-5 py-3 hover:bg-saveTealDark">Search</button>
+          <input name="zip" id="zip" placeholder="ZIP code" pattern="\d{5}" class="w-full sm:flex-1 rounded-xl border-slate-300 focus:border-saveWine focus:ring-saveWine py-3 px-3" />
+          <button class="sm:w-auto sm:shrink-0 rounded-xl bg-saveTeal text-white font-semibold px-5 py-3 hover:bg-saveTealDark">Search</button>
         </form>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Align search form elements on results page so the button sits beside the specialty and ZIP inputs on desktop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8da2682d08326b31d0372ef663ba5