### PR TITLE
Always show Belong Health logo in navbar

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,7 +13,10 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
+        <img src="assets/savewell-logo.png" class="h-8 w-auto" alt="SaveWell"/>
+        <img src="assets/belong-health-logo-trim2.png" class="h-5 sm:h-6 w-auto" alt="Belong Health"/>
+      </a>
       <div class="flex items-center gap-6">
         <nav class="hidden md:flex items-center gap-6 text-[15px]">
           <a class="hover:text-saveWine" href="providers.html">Join the Network</a>
@@ -88,15 +91,6 @@
     const menuBtn = document.getElementById('menuBtn');
     const mobileMenu = document.getElementById('mobileMenu');
     if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-    const subdomain = window.location.hostname.split('.')[0];
-    if (subdomain.includes('belong')) {
-      const logoContainer = document.querySelector('header a');
-      const secondLogo = document.createElement('img');
-      secondLogo.src = 'assets/belong-health-logo-trim2.png';
-      secondLogo.alt = 'Second Logo';
-      secondLogo.className = 'h-8 w-auto';
-      logoContainer.appendChild(secondLogo);
-    }
   </script>
 </body>
 </html>

--- a/brokers.html
+++ b/brokers.html
@@ -12,7 +12,10 @@
 <body class="font-sans text-slate-800">
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
+        <img src="assets/savewell-logo.png" class="h-8 w-auto" alt="SaveWell"/>
+        <img src="assets/belong-health-logo-trim2.png" class="h-5 sm:h-6 w-auto" alt="Belong Health"/>
+      </a>
       <div class="flex items-center gap-6">
         <nav class="hidden md:flex items-center gap-6 text-[15px]">
           <a class="hover:text-saveWine" href="providers.html">Join the Network</a>
@@ -90,22 +93,11 @@
     </div>
   </footer>
 
-  <!-- Script to update navbar for 'belong' subdomain -->
-  <!-- Removed script that changes text for 'belong' subdomain -->
   <script>
     const y = document.getElementById('year'); if (y) y.textContent = new Date().getFullYear();
     const menuBtn = document.getElementById('menuBtn');
     const mobileMenu = document.getElementById('mobileMenu');
     if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-    const subdomain = window.location.hostname.split('.')[0];
-    if (subdomain.includes('belong')) {
-      const logoContainer = document.querySelector('header a');
-      const secondLogo = document.createElement('img');
-      secondLogo.src = 'assets/belong-health-logo-trim2.png';
-      secondLogo.alt = 'Second Logo';
-      secondLogo.className = 'h-8 w-auto';
-      logoContainer.appendChild(secondLogo);
-    }
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -41,8 +41,9 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3">
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
         <img src="assets/savewell-logo.png" alt="SaveWell" class="h-8 w-auto" />
+        <img src="assets/belong-health-logo-trim2.png" alt="Belong Health" class="h-5 sm:h-6 w-auto" />
       </a>
       <div class="flex items-center gap-6">
         <nav class="hidden md:flex items-center gap-6 text-[15px]">
@@ -318,16 +319,6 @@
     // Footer year
     const y = document.getElementById('year'); if (y) y.textContent = new Date().getFullYear();
 
-    // Check subdomain for second logo
-    const subdomain = window.location.hostname.split('.')[0];
-    if (subdomain.includes('belong')) {
-      const logoContainer = document.querySelector('header a');
-      const secondLogo = document.createElement('img');
-      secondLogo.src = 'assets/belong-health-logo-trim2.png';
-      secondLogo.alt = 'Second Logo';
-      secondLogo.className = 'h-8 w-auto';
-      logoContainer.appendChild(secondLogo);
-    }
   </script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -33,8 +33,9 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3">
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
         <img src="assets/savewell-logo.png" alt="SaveWell" class="h-8 w-auto" />
+        <img src="assets/belong-health-logo-trim2.png" alt="Belong Health" class="h-5 sm:h-6 w-auto" />
       </a>
       <div class="flex items-center gap-6">
         <nav class="hidden md:flex items-center gap-6 text-[15px]">
@@ -60,8 +61,6 @@
     </div>
   </header>
   
-    <!-- Script to update navbar for 'belong' subdomain -->
-  <!-- Removed script that changes text for 'belong' subdomain -->
 
   <main class="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-saveTeal/10 px-4">
     <div class="w-full max-w-sm">
@@ -139,16 +138,6 @@
     // Footer year
     const y = document.getElementById('year'); if (y) y.textContent = new Date().getFullYear();
 
-    // Check subdomain for second logo
-    const subdomain = window.location.hostname.split('.')[0];
-    if (subdomain.includes('belong')) {
-      const logoContainer = document.querySelector('header a');
-      const secondLogo = document.createElement('img');
-      secondLogo.src = 'assets/belong-health-logo-trim2.png';
-      secondLogo.alt = 'Second Logo';
-      secondLogo.className = 'h-8 w-auto';
-      logoContainer.appendChild(secondLogo);
-    }
 
     // Login form handler
     const loginForm = document.getElementById('loginForm');

--- a/patients.html
+++ b/patients.html
@@ -41,8 +41,9 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3">
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
         <img src="assets/savewell-logo.png" alt="SaveWell" class="h-8 w-auto" />
+        <img src="assets/belong-health-logo-trim2.png" alt="Belong Health" class="h-5 sm:h-6 w-auto" />
       </a>
       <div class="flex items-center gap-6">
         <nav class="hidden md:flex items-center gap-6 text-[15px]">

--- a/payers.html
+++ b/payers.html
@@ -12,7 +12,10 @@
 <body class="font-sans text-slate-800">
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
+        <img src="assets/savewell-logo.png" class="h-8 w-auto" alt="SaveWell"/>
+        <img src="assets/belong-health-logo-trim2.png" class="h-5 sm:h-6 w-auto" alt="Belong Health"/>
+      </a>
       <nav class="hidden md:flex items-center gap-6 text-[15px]">
   <a class="hover:text-saveWine" href="providers.html">Join the Network</a>
         <!-- <a class="text-saveWine font-semibold" href="payers.html">For Payers</a> -->
@@ -100,22 +103,11 @@
     </div>
   </footer>
 
-  <!-- Script to update navbar for 'belong' subdomain -->
-  <!-- Removed script that changes text for 'belong' subdomain -->
   <script>
     const y = document.getElementById('year'); if (y) y.textContent = new Date().getFullYear();
     const menuBtn = document.getElementById('menuBtn');
     const mobileMenu = document.getElementById('mobileMenu');
     if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-    const subdomain = window.location.hostname.split('.')[0];
-    if (subdomain.includes('belong')) {
-      const logoContainer = document.querySelector('header a');
-      const secondLogo = document.createElement('img');
-      secondLogo.src = 'assets/belong-health-logo-trim2.png';
-      secondLogo.alt = 'Second Logo';
-      secondLogo.className = 'h-8 w-auto';
-      logoContainer.appendChild(secondLogo);
-    }
   </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -13,7 +13,10 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
+        <img src="assets/savewell-logo.png" class="h-8 w-auto" alt="SaveWell"/>
+        <img src="assets/belong-health-logo-trim2.png" class="h-5 sm:h-6 w-auto" alt="Belong Health"/>
+      </a>
       <div class="flex items-center gap-6">
         <nav class="hidden md:flex items-center gap-6 text-[15px]">
           <a class="hover:text-saveWine" href="providers.html">Join the Network</a>
@@ -90,15 +93,6 @@
     const menuBtn = document.getElementById('menuBtn');
     const mobileMenu = document.getElementById('mobileMenu');
     if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-    const subdomain = window.location.hostname.split('.')[0];
-    if (subdomain.includes('belong')) {
-      const logoContainer = document.querySelector('header a');
-      const secondLogo = document.createElement('img');
-      secondLogo.src = 'assets/belong-health-logo-trim2.png';
-      secondLogo.alt = 'Second Logo';
-      secondLogo.className = 'h-8 w-auto';
-      logoContainer.appendChild(secondLogo);
-    }
   </script>
 </body>
 </html>

--- a/providers.html
+++ b/providers.html
@@ -13,7 +13,10 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
+        <img src="assets/savewell-logo.png" class="h-8 w-auto" alt="SaveWell"/>
+        <img src="assets/belong-health-logo-trim2.png" class="h-5 sm:h-6 w-auto" alt="Belong Health"/>
+      </a>
       <div class="flex items-center gap-6">
         <nav class="hidden md:flex items-center gap-6 text-[15px]">
           <a class="text-saveWine font-semibold" href="providers.html">Join the Network</a>
@@ -103,22 +106,11 @@
     </div>
   </footer>
 
-  <!-- Script to update navbar for 'belong' subdomain -->
-  <!-- Removed script that changes text for 'belong' subdomain -->
   <script>
     const y = document.getElementById('year'); if (y) y.textContent = new Date().getFullYear();
     const menuBtn = document.getElementById('menuBtn');
     const mobileMenu = document.getElementById('mobileMenu');
     if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-    const subdomain = window.location.hostname.split('.')[0];
-    if (subdomain.includes('belong')) {
-      const logoContainer = document.querySelector('header a');
-      const secondLogo = document.createElement('img');
-      secondLogo.src = 'assets/belong-health-logo-trim2.png';
-      secondLogo.alt = 'Second Logo';
-      secondLogo.className = 'h-8 w-auto';
-      logoContainer.appendChild(secondLogo);
-    }
   </script>
 </body>
 </html>

--- a/results.html
+++ b/results.html
@@ -15,7 +15,10 @@
   <!-- Navbar (same as index) -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
+        <img src="assets/savewell-logo.png" class="h-8 w-auto" alt="SaveWell"/>
+        <img src="assets/belong-health-logo-trim2.png" class="h-5 sm:h-6 w-auto" alt="Belong Health"/>
+      </a>
       <div class="flex items-center gap-6">
         <nav class="hidden md:flex items-center gap-6 text-[15px]">
           <a class="hover:text-saveWine" href="providers.html">Join the Network</a>
@@ -40,8 +43,6 @@
     </div>
   </header>
 
-    <!-- Script to update navbar for 'belong' subdomain -->
-  <!-- Removed script that changes text for 'belong' subdomain -->
 
   <main>
     <!-- Search again bar -->
@@ -129,15 +130,6 @@
     const menuBtn = document.getElementById('menuBtn');
     const mobileMenu = document.getElementById('mobileMenu');
     if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-    const subdomain = window.location.hostname.split('.')[0];
-    if (subdomain.includes('belong')) {
-      const logoContainer = document.querySelector('header a');
-      const secondLogo = document.createElement('img');
-      secondLogo.src = 'assets/belong-health-logo-trim2.png';
-      secondLogo.alt = 'Second Logo';
-      secondLogo.className = 'h-8 w-auto';
-      logoContainer.appendChild(secondLogo);
-    }
 
     // Load provider data from external JSON file
     let DOCTORS = [];

--- a/terms.html
+++ b/terms.html
@@ -13,7 +13,10 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-      <a href="index.html" class="flex items-center gap-3"><img src="assets/savewell-logo.png" class="h-8" alt="SaveWell"/></a>
+      <a href="index.html" class="flex flex-col sm:flex-row items-start sm:items-end gap-1 sm:gap-3">
+        <img src="assets/savewell-logo.png" class="h-8 w-auto" alt="SaveWell"/>
+        <img src="assets/belong-health-logo-trim2.png" class="h-5 sm:h-6 w-auto" alt="Belong Health"/>
+      </a>
       <div class="flex items-center gap-6">
         <nav class="hidden md:flex items-center gap-6 text-[15px]">
           <a class="hover:text-saveWine" href="providers.html">Join the Network</a>
@@ -90,15 +93,6 @@
     const menuBtn = document.getElementById('menuBtn');
     const mobileMenu = document.getElementById('mobileMenu');
     if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-    const subdomain = window.location.hostname.split('.')[0];
-    if (subdomain.includes('belong')) {
-      const logoContainer = document.querySelector('header a');
-      const secondLogo = document.createElement('img');
-      secondLogo.src = 'assets/belong-health-logo-trim2.png';
-      secondLogo.alt = 'Second Logo';
-      secondLogo.className = 'h-8 w-auto';
-      logoContainer.appendChild(secondLogo);
-    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Always display the Belong Health logo beside the SaveWell logo in the navbar.
- Stack the logos vertically on narrow screens to avoid overlap and tweak sizing for better alignment.
- Remove domain-based JavaScript that previously injected the Belong logo only on `belong` subdomains.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e430f964832694dd06db77bd60d4