### PR TITLE
Fix footer image overlap on small screens

### DIFF
--- a/about.html
+++ b/about.html
@@ -80,7 +80,7 @@
       </div>
       <p class="text-xs text-slate-500 mt-8">© <span id="year"></span> SaveWell. All rights reserved.</p>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>

--- a/brokers.html
+++ b/brokers.html
@@ -88,7 +88,7 @@
       </div>
       <p class="text-xs text-slate-500 mt-8">© <span id="year"></span> SaveWell. All rights reserved.</p>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
         </div>
       </div>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>

--- a/login.html
+++ b/login.html
@@ -123,7 +123,7 @@
       </div>
       <p class="text-xs text-slate-500 mt-8">© <span id="year"></span> SaveWell. All rights reserved.</p>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>

--- a/patients.html
+++ b/patients.html
@@ -233,7 +233,7 @@
       </div>
       <p class="text-xs text-slate-500 mt-8">© <span id="year"></span> SaveWell. All rights reserved.</p>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>

--- a/payers.html
+++ b/payers.html
@@ -98,7 +98,7 @@
       </div>
       <p class="text-xs text-slate-500 mt-8">© <span id="year"></span> SaveWell. All rights reserved.</p>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>

--- a/privacy.html
+++ b/privacy.html
@@ -82,7 +82,7 @@
       </div>
       <p class="text-xs text-slate-500 mt-8">© <span id="year"></span> SaveWell. All rights reserved.</p>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>

--- a/providers.html
+++ b/providers.html
@@ -101,7 +101,7 @@
       </div>
       <p class="text-xs text-slate-500 mt-8">© <span id="year"></span> SaveWell. All rights reserved.</p>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>

--- a/results.html
+++ b/results.html
@@ -118,7 +118,7 @@
       </div>
       <p class="text-xs text-slate-500 mt-8">© <span id="year"></span> SaveWell. All rights reserved.</p>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>

--- a/terms.html
+++ b/terms.html
@@ -82,7 +82,7 @@
       </div>
       <p class="text-xs text-slate-500 mt-8">© <span id="year"></span> SaveWell. All rights reserved.</p>
       <div class="w-full flex justify-center mt-8">
-  <img src="assets/medicare-people.png" alt="Medicare People" class="w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none mb-0" style="display:block; margin-top:-4rem;" />
+  <img src="assets/medicare-people.png" alt="Medicare People" class="block w-full max-h-40 sm:max-h-56 lg:max-h-72 object-cover pointer-events-none select-none sm:-mt-16 mb-0" />
       </div>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- remove inline negative margin from footer people image
- add responsive Tailwind class so image sits below text on small screens

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ec001b808326a8a41ef8cdf936bc