### PR TITLE
Require specialty or ZIP for search submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
         <p class="mt-4 text-lg text-slate-600 max-w-xl">Patients save money on health plan premiums when they receive care from preferred, high-quality doctors in your area.</p>
 
         <!-- Search Bar -->
-        <form action="results.html" method="get" class="mt-8 bg-white/95 border border-slate-200 rounded-2xl shadow-sm p-3 md:p-4 flex flex-col md:flex-row gap-3">
+        <form id="searchForm" action="results.html" method="get" class="mt-8 bg-white/95 border border-slate-200 rounded-2xl shadow-sm p-3 md:p-4 flex flex-col md:flex-row gap-3">
           <label class="sr-only" for="specialty">Specialty</label>
           <select id="specialty" name="specialty" class="w-full md:w-1/3 rounded-xl border-slate-300 focus:border-saveWine focus:ring-saveWine text-[15px] py-3">
             <option value="" selected>Choose a specialty</option>
@@ -272,6 +272,19 @@
     const menuBtn = document.getElementById('menuBtn');
     const mobileMenu = document.getElementById('mobileMenu');
     if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+    // Require at least one field before searching
+    const searchForm = document.getElementById('searchForm');
+    if (searchForm) {
+      searchForm.addEventListener('submit', e => {
+        const spec = searchForm.specialty.value.trim();
+        const zip = searchForm.zip.value.trim();
+        if (!spec && !zip) {
+          e.preventDefault();
+          alert('Please enter a specialty or ZIP code.');
+        }
+      });
+    }
 
     // Featured doctors carousel
     const providerIds = [175, 5, 423, 547, 48, 443, 65];

--- a/results.html
+++ b/results.html
@@ -48,7 +48,7 @@
     <!-- Search again bar -->
     <section class="bg-slate-50 border-b border-slate-200">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
-        <form action="results.html" method="get" class="bg-white border rounded-2xl p-3 flex flex-col sm:flex-row gap-3">
+        <form id="searchForm" action="results.html" method="get" class="bg-white border rounded-2xl p-3 flex flex-col sm:flex-row gap-3">
           <select name="specialty" id="specialty" class="w-full sm:w-1/3 rounded-xl border-slate-300 focus:border-saveWine focus:ring-saveWine py-3">
             <option value="">All specialties</option>
             <option>Ambulatory Surgical Center</option>
@@ -130,6 +130,19 @@
     const menuBtn = document.getElementById('menuBtn');
     const mobileMenu = document.getElementById('mobileMenu');
     if (menuBtn) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+    // Require at least one field before searching
+    const searchForm = document.getElementById('searchForm');
+    if (searchForm) {
+      searchForm.addEventListener('submit', e => {
+        const spec = searchForm.specialty.value.trim();
+        const zip = searchForm.zip.value.trim();
+        if (!spec && !zip) {
+          e.preventDefault();
+          alert('Please enter a specialty or ZIP code.');
+        }
+      });
+    }
 
     // Load provider data from external JSON file
     let DOCTORS = [];


### PR DESCRIPTION
## Summary
- Prevent empty search submissions by requiring specialty or ZIP code on home and results pages

## Testing
- `npx -y html-validate index.html results.html` *(fails: 403 Forbidden fetching html-validate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b61066248326979a78321b5f84ba